### PR TITLE
integrate calendar into cards

### DIFF
--- a/components/calendar/DailyAppointments.tsx
+++ b/components/calendar/DailyAppointments.tsx
@@ -1,20 +1,10 @@
 import { FunctionComponent, h } from "preact";
 import AppointmentDay from "./AppointmentDay.tsx";
 import AppointmentCardDetails from "./AppointmentCardDetails.tsx";
+import { DoctorAppointment } from "../../types.ts";
 
 interface DailyAppointmentsProps {
-  dailyAppointments: Array<{
-    day: number;
-    weekday: string;
-    appointments: Array<{
-      stripeColor: string;
-      time: string;
-      patientName: string;
-      patientAge: number;
-      clinicName: string;
-      durationMinutes: string;
-    }>;
-  }>;
+  dailyAppointments: Array<DoctorAppointment>;
 }
 
 const DailyAppointments: FunctionComponent<DailyAppointmentsProps> = ({

--- a/routes/app/calendar.tsx
+++ b/routes/app/calendar.tsx
@@ -3,7 +3,7 @@ import { JSX } from "preact";
 import DailyAppointments from "../../components/calendar/DailyAppointments.tsx";
 import { Handlers, PageProps } from "$fresh/server.ts";
 import { Agent } from "../../external-clients/google.ts";
-import { GCalEventsResponse } from "../../types.ts";
+import { DoctorAppointment, GCalEventsResponse } from "../../types.ts";
 import { WithSession } from "fresh_session";
 
 function CalendarLink(
@@ -19,21 +19,7 @@ function CalendarLink(
   );
 }
 
-let dailyAppointments: {
-  day: number;
-  weekday: string;
-  appointments: {
-    stripeColor: string; // Just blue for now
-    // Just blue for now
-    time: string;
-    patientName: string; // Remove the prefix "Appointment with "
-    // Remove the prefix "Appointment with "
-    patientAge: number; // Not in the google calendar
-    // Not in the google calendar
-    clinicName: string;
-    durationMinutes: string;
-  }[];
-}[];
+let dailyAppointments: DoctorAppointment[];
 
 export const handler: Handlers<
   { events: GCalEventsResponse },
@@ -76,18 +62,7 @@ export const handler: Handlers<
     });
 
     // Merge appointments for the same day/weekday
-    const mergedAppointments: {
-      day: number;
-      weekday: string;
-      appointments: {
-        stripeColor: string; // Just blue for now
-        time: string;
-        patientName: string; // Remove the prefix "Appointment with "
-        patientAge: number; // Not in the google calendar
-        clinicName: string;
-        durationMinutes: string;
-      }[];
-    }[] = [];
+    const mergedAppointments: DoctorAppointment[] = [];
     mappedAppointments.forEach((appointment) => {
       const existingAppointment = mergedAppointments.find((a) =>
         a.day === appointment.day && a.weekday === appointment.weekday

--- a/types.ts
+++ b/types.ts
@@ -588,3 +588,18 @@ export type WhatsAppSendable = string | {
   buttonText: string;
   options: MessageOption[];
 };
+export type DoctorAppointment = {
+  day: number;
+  weekday: string;
+  appointments: {
+    stripeColor: string; // Just blue for now
+    // Just blue for now
+    time: string;
+    patientName: string; // Remove the prefix "Appointment with "
+    // Remove the prefix "Appointment with "
+    patientAge: number; // Not in the google calendar
+    // Not in the google calendar
+    clinicName: string;
+    durationMinutes: string;
+  }[];
+};


### PR DESCRIPTION
Addresses calendar ui task

This change allows cards to display meeting data from google calendar events. Currently, events are being filtered so that previous events do not appear, and only events in the current 7 day cycle are displayed.

Age is not currently displayed, as it is not associated with a calendar event.

![image](https://user-images.githubusercontent.com/90505373/236370718-565b96b9-df3d-4467-9ba3-195c643fb7e7.png)
notice that there are 3 events, and only the one that's in the future is appearing.