### PR TITLE
add turbolinks

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -15,6 +15,13 @@ export default function Layout(props: LayoutProps) {
         <title>{props.title}</title>
         <link rel="stylesheet" href="/normalize.css" />
         <link rel="stylesheet" href="/main.css" />
+        <script
+          defer
+          src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js"
+          integrity="sha512-G3jAqT2eM4MMkLMyQR5YBhvN5/Da3IG6kqgYqU9zlIH4+2a+GuMdLb5Kpxy6ItMdCfgaKlo2XFhI0dHtMJjoRw=="
+          crossOrigin="anonymous"
+          referrerpolicy="no-referrer"
+        />
       </Head>
       <body className="h-full relative">
         <nav>


### PR DESCRIPTION
A drop-in way to get some smoother navigation for a very low cost for multipage apps. I don't know why [the repo](https://github.com/turbolinks/turbolinks) is archived, but I tested and it appears to work flawlessly. Navigate to another page and you don't get a full refresh, just the content that you want replaced is