### PR TITLE
feature/avaliability overlap

### DIFF
--- a/islands/set-availability-form.tsx
+++ b/islands/set-availability-form.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'preact/hooks'
+import { useRef, useState } from 'preact/hooks'
 import range from '../util/range.ts'
 import padLeft from '../util/padLeft.ts'
 import { AvailabilityJSON, DayOfWeek, Time, TimeWindow } from '../types.ts'
@@ -277,11 +277,12 @@ const days: Array<DayOfWeek> = [
   'Saturday',
 ]
 
-
 //Takes AvaliabilityJSON and returns null if there's no overlapping times
 //returns a AvailabilityJSON of the overlapping times if there is an overlap
-export function validateNoOverlap(availability: AvailabilityJSON) : AvailabilityJSON | null {
-  const overlappingTimes : AvailabilityJSON = {
+export function validateNoOverlap(
+  availability: AvailabilityJSON,
+): AvailabilityJSON | null {
+  const overlappingTimes: AvailabilityJSON = {
     Sunday: [],
     Monday: [],
     Tuesday: [],
@@ -290,54 +291,53 @@ export function validateNoOverlap(availability: AvailabilityJSON) : Availability
     Friday: [],
     Saturday: [],
   }
-  let doesOverlap = false;
+  let doesOverlap = false
 
-  days.forEach( weekday => {
-    for (let i = 0; i < availability[weekday].length; i++)
-    {
-      const targetTime : TimeWindow = availability[weekday].at(i)!;
-      for (let n = 0; n < availability[weekday].length; n++)
-      {
-        if (n == i) {continue;}
-        if (overlaps(targetTime,availability[weekday].at(n)!))
-        {
-          doesOverlap = true;
+  days.forEach((weekday) => {
+    for (let i = 0; i < availability[weekday].length; i++) {
+      const targetTime: TimeWindow = availability[weekday].at(i)!
+      for (let n = 0; n < availability[weekday].length; n++) {
+        if (n == i) continue
+        if (overlaps(targetTime, availability[weekday].at(n)!)) {
+          doesOverlap = true
           overlappingTimes[weekday].push(targetTime)
         }
       }
     }
   })
-  if (doesOverlap){return overlappingTimes;}
-  else {return null;}
+  if (doesOverlap) return overlappingTimes
+  else return null
 }
 
 //Converts two TimeWindows into minutes, then checks if they overlap, returns `targetTime` if they do overlap
 //else returns null
-function overlaps(targetTime : TimeWindow, checkedAgainst : TimeWindow) : TimeWindow | null {
-  const targetStartTime = timeToMinute(targetTime.start);
-  const targetEndTime = timeToMinute(targetTime.end);
-  const checkedStartTime = timeToMinute(checkedAgainst.start);
-  const checkedEndTime = timeToMinute(checkedAgainst.end);
-  if ((targetEndTime > checkedStartTime) && (targetStartTime < checkedEndTime))
-  {
-    return targetTime;
+function overlaps(
+  targetTime: TimeWindow,
+  checkedAgainst: TimeWindow,
+): TimeWindow | null {
+  const targetStartTime = timeToMinute(targetTime.start)
+  const targetEndTime = timeToMinute(targetTime.end)
+  const checkedStartTime = timeToMinute(checkedAgainst.start)
+  const checkedEndTime = timeToMinute(checkedAgainst.end)
+  if (
+    (targetEndTime > checkedStartTime) && (targetStartTime < checkedEndTime)
+  ) {
+    return targetTime
   }
-  return null;
+  return null
 
-  function timeToMinute(time : Time) : number
-  {
-    let hour = time.hour;
-    if (time.amPm == "pm") {hour += 12;}
-    return (hour * 60) + time.minute;
+  function timeToMinute(time: Time): number {
+    let hour = time.hour
+    if (time.amPm == 'pm') hour += 12
+    return (hour * 60) + time.minute
   }
 }
 
 //Converts the form data into an AvaliabilityJSON and then validates the form
 //feasibly you could add more validation functions here
-function validateForm(event : HTMLFormElement)
-{
-  const data = new FormData(event);
-  const availability : AvailabilityJSON = {
+function validateForm(event: HTMLFormElement) {
+  const data = new FormData(event)
+  const availability: AvailabilityJSON = {
     Sunday: [],
     Monday: [],
     Tuesday: [],
@@ -347,58 +347,88 @@ function validateForm(event : HTMLFormElement)
     Saturday: [],
   }
   data.forEach((value, key) => {
-    const toSet = /^\d+$/g.test(value.toString()) ? parseInt(value.toString()) : value
+    const toSet = /^\d+$/g.test(value.toString())
+      ? parseInt(value.toString())
+      : value
     set(availability, key, toSet)
   })
-  return validateNoOverlap(availability);
+  return validateNoOverlap(availability)
 }
 
-function OverlapMessage({ overlapTimeSlots }: { overlapTimeSlots: AvailabilityJSON}) {
+function OverlapMessage(
+  { overlapTimeSlots }: { overlapTimeSlots: AvailabilityJSON },
+) {
   const overlapDays = Object.keys(overlapTimeSlots).reduce((acc, cur) => {
     if (overlapTimeSlots[cur as DayOfWeek].length > 1) {
-      acc.push(cur as DayOfWeek);
+      acc.push(cur as DayOfWeek)
     }
-    return acc;
+    return acc
   }, [] as DayOfWeek[])
   return (
     <>
-      There are some overlapping time slots on the following days, please update them accordingly: {overlapDays.join(', ')}
+      There are some overlapping time slots on the following days, please update
+      them accordingly: {overlapDays.join(', ')}
     </>
   )
 }
 
-function WarningModal({ onConfirm, overlapTimeSlots }: { 
-  onConfirm(): void, overlapTimeSlots: AvailabilityJSON | null
+function WarningModal({ onConfirm, overlapTimeSlots }: {
+  onConfirm(): void
+  overlapTimeSlots: AvailabilityJSON | null
 }) {
-  
   return (
-    <div class="relative z-10" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div
+      class='relative z-10'
+      aria-labelledby='modal-title'
+      role='dialog'
+      aria-modal='true'
+    >
+      <div class='fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity'>
+      </div>
 
-      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
-
-      <div class="fixed inset-0 z-10 overflow-y-auto">
-        <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-          <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
-            <div class="sm:flex sm:items-start">
-              <div class="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
-                <svg class="h-6 w-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+      <div class='fixed inset-0 z-10 overflow-y-auto'>
+        <div class='flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0'>
+          <div class='relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6'>
+            <div class='sm:flex sm:items-start'>
+              <div class='mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10'>
+                <svg
+                  class='h-6 w-6 text-red-600'
+                  fill='none'
+                  viewBox='0 0 24 24'
+                  stroke-width='1.5'
+                  stroke='currentColor'
+                  aria-hidden='true'
+                >
+                  <path
+                    stroke-linecap='round'
+                    stroke-linejoin='round'
+                    d='M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z'
+                  />
                 </svg>
               </div>
-              <div class="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
-                <h3 class="text-base font-semibold leading-6 text-gray-900" id="modal-title">Time Slots Overlap</h3>
-                <div class="mt-2">
-                  <p class="text-sm text-gray-500">
-                    {
-                      overlapTimeSlots != null &&
-                      <OverlapMessage overlapTimeSlots={overlapTimeSlots} />
-                    }
+              <div class='mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left'>
+                <h3
+                  class='text-base font-semibold leading-6 text-gray-900'
+                  id='modal-title'
+                >
+                  Time Slots Overlap
+                </h3>
+                <div class='mt-2'>
+                  <p class='text-sm text-gray-500'>
+                    {overlapTimeSlots != null &&
+                      <OverlapMessage overlapTimeSlots={overlapTimeSlots} />}
                   </p>
                 </div>
               </div>
             </div>
-            <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
-              <button type="button" class="mt-3 inline-flex justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto" onClick={onConfirm}>Confirm</button>
+            <div class='mt-5 sm:mt-4 sm:flex sm:flex-row-reverse'>
+              <button
+                type='button'
+                class='mt-3 inline-flex justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto'
+                onClick={onConfirm}
+              >
+                Confirm
+              </button>
             </div>
           </div>
         </div>
@@ -410,28 +440,27 @@ function WarningModal({ onConfirm, overlapTimeSlots }: {
 export default function SetAvailabilityForm(
   { availability }: { availability: AvailabilityJSON },
 ) {
-  const formRef = useRef<HTMLFormElement>(null);
-  const [isShowModal, setIsShowModal] = useState(false);
-  const onConfirm = () => setIsShowModal(false);
-  const handleValidationFailed = () => setIsShowModal(true);
-  const [overlapTimeSlots, setOverlapTimeSlots] = useState<AvailabilityJSON | null>(null);
-  let response : AvailabilityJSON | null = null;
+  const formRef = useRef<HTMLFormElement>(null)
+  const [isShowModal, setIsShowModal] = useState(false)
+  const onConfirm = () => setIsShowModal(false)
+  const handleValidationFailed = () => setIsShowModal(true)
+  const [overlapTimeSlots, setOverlapTimeSlots] = useState<
+    AvailabilityJSON | null
+  >(null)
   return (
     <form
       method='POST'
       action='/api/set-availability'
       className='container p-1'
       ref={formRef}
-      onSubmit={event => {
-        event.preventDefault();
-        response = validateForm(event.currentTarget)
-        if (response == null)
-        {
-          formRef.current?.submit();
-        }
-        else 
-        {
-          handleValidationFailed();
+      onSubmit={(event) => {
+        event.preventDefault()
+        const result = validateForm(event.currentTarget)
+        setOverlapTimeSlots(result)
+        if (result === null) {
+          formRef.current?.submit()
+        } else {
+          handleValidationFailed()
         }
       }}
     >
@@ -445,9 +474,12 @@ export default function SetAvailabilityForm(
           <DayInput key={day} day={day} timeWindows={availability[day]} />
         ))}
       </div>
-      {
-        isShowModal && <WarningModal onConfirm={onConfirm} overlapTimeSlots={response} />
-      }
+      {(isShowModal && overlapTimeSlots) && (
+        <WarningModal
+          onConfirm={onConfirm}
+          overlapTimeSlots={overlapTimeSlots}
+        />
+      )}
       <div className='container grid gap-x-2 grid-cols-2'>
         <button
           type='button'

--- a/test/overlap.test.ts
+++ b/test/overlap.test.ts
@@ -1,160 +1,212 @@
-import { assertEquals } from "std/testing/asserts.ts";
-import { validateNoOverlap } from "../islands/set-availability-form.tsx";
+import { assertEquals } from 'std/testing/asserts.ts'
+import { validateNoOverlap } from '../islands/set-availability-form.tsx'
 import { AvailabilityJSON } from '../types.ts'
 
 //no overlap : single time slot
-Deno.test("validateNoOverlap should return null for non-overlapping time slots", () => {
-    const input: AvailabilityJSON = {
-      Sunday: [],
-      Monday: [{start: { hour: 9, minute: 0, amPm: 'am' }, end: { hour: 5, minute: 0, amPm: 'pm' }}],
-      Tuesday: [],
-      Wednesday: [],
-      Thursday: [],
-      Friday: [],
-      Saturday: [],
-    };
-  
-    const result = validateNoOverlap(input);
-  
-    assertEquals(result, null);
-  });
+Deno.test('validateNoOverlap should return null for non-overlapping time slots', () => {
+  const input: AvailabilityJSON = {
+    Sunday: [],
+    Monday: [{
+      start: { hour: 9, minute: 0, amPm: 'am' },
+      end: { hour: 5, minute: 0, amPm: 'pm' },
+    }],
+    Tuesday: [],
+    Wednesday: [],
+    Thursday: [],
+    Friday: [],
+    Saturday: [],
+  }
 
-  //no overlap : same time on different days
-  Deno.test("validateNoOverlap should return null for non-overlapping time slots", () => {
-    const input: AvailabilityJSON = {
-      Sunday: [],
-      Monday: [{start: { hour: 9, minute: 0, amPm: 'am' }, end: { hour: 5, minute: 0, amPm: 'pm' }}],
-      Tuesday: [],
-      Wednesday: [{start: { hour: 10, minute: 0, amPm: 'am' }, end: { hour: 12, minute: 0, amPm: 'pm' }}],
-      Thursday: [],
-      Friday: [],
-      Saturday: [{start: { hour: 9, minute: 0, amPm: 'am' }, end: { hour: 5, minute: 0, amPm: 'pm' }}],
-    };
-  
-    const result = validateNoOverlap(input);
-  
-    assertEquals(result, null);
-  });
+  const result = validateNoOverlap(input)
 
-  //overlap:partially pattern 1 (9am-5pm and 4pm-6pm)
-  Deno.test("validateNoOverlap should return overlapping times for partially overlapping time slots", () => {
-    const input: AvailabilityJSON = {
-      Sunday: [],
-      Monday: [
-        {start: { hour: 9, minute: 0, amPm: 'am' }, end: { hour: 5, minute: 0, amPm: 'pm' }},
-        {start: { hour: 4, minute: 0, amPm: 'pm' }, end: { hour: 6, minute: 0, amPm: 'pm' }}
-      ],
-      Tuesday: [],
-      Wednesday: [],
-      Thursday: [],
-      Friday: [],
-      Saturday: [],
-    };
-  
-    const expectedOutput: AvailabilityJSON = {
-      Sunday: [],
-      Monday: [
-        {start: { hour: 9, minute: 0, amPm: 'am' }, end: { hour: 5, minute: 0, amPm: 'pm' }},
-        {start: { hour: 4, minute: 0, amPm: 'pm' }, end: { hour: 6, minute: 0, amPm: 'pm' }}
-      ],
-      Tuesday: [],
-      Wednesday: [],
-      Thursday: [],
-      Friday: [],
-      Saturday: [],
-    };
-  
-    const result = validateNoOverlap(input);
-  
-    assertEquals(result, expectedOutput);
-  });
+  assertEquals(result, null)
+})
+
+//no overlap : same time on different days
+Deno.test('validateNoOverlap should return null for non-overlapping time slots', () => {
+  const input: AvailabilityJSON = {
+    Sunday: [],
+    Monday: [{
+      start: { hour: 9, minute: 0, amPm: 'am' },
+      end: { hour: 5, minute: 0, amPm: 'pm' },
+    }],
+    Tuesday: [],
+    Wednesday: [{
+      start: { hour: 10, minute: 0, amPm: 'am' },
+      end: { hour: 12, minute: 0, amPm: 'pm' },
+    }],
+    Thursday: [],
+    Friday: [],
+    Saturday: [{
+      start: { hour: 9, minute: 0, amPm: 'am' },
+      end: { hour: 5, minute: 0, amPm: 'pm' },
+    }],
+  }
+
+  const result = validateNoOverlap(input)
+
+  assertEquals(result, null)
+})
+
+//overlap:partially pattern 1 (9am-5pm and 4pm-6pm)
+Deno.test('validateNoOverlap should return overlapping times for partially overlapping time slots', () => {
+  const input: AvailabilityJSON = {
+    Sunday: [],
+    Monday: [
+      {
+        start: { hour: 9, minute: 0, amPm: 'am' },
+        end: { hour: 5, minute: 0, amPm: 'pm' },
+      },
+      {
+        start: { hour: 4, minute: 0, amPm: 'pm' },
+        end: { hour: 6, minute: 0, amPm: 'pm' },
+      },
+    ],
+    Tuesday: [],
+    Wednesday: [],
+    Thursday: [],
+    Friday: [],
+    Saturday: [],
+  }
+
+  const expectedOutput: AvailabilityJSON = {
+    Sunday: [],
+    Monday: [
+      {
+        start: { hour: 9, minute: 0, amPm: 'am' },
+        end: { hour: 5, minute: 0, amPm: 'pm' },
+      },
+      {
+        start: { hour: 4, minute: 0, amPm: 'pm' },
+        end: { hour: 6, minute: 0, amPm: 'pm' },
+      },
+    ],
+    Tuesday: [],
+    Wednesday: [],
+    Thursday: [],
+    Friday: [],
+    Saturday: [],
+  }
+
+  const result = validateNoOverlap(input)
+
+  assertEquals(result, expectedOutput)
+})
 
 //overlap:partially pattern 2 (3pm-6pm and 10am-5pm)
-  Deno.test("validateNoOverlap should return overlapping times for partially overlapping time slots", () => {
-    const input: AvailabilityJSON = {
-      Sunday: [],
-      Monday: [],
-      Tuesday: [{start: { hour: 3, minute: 0, amPm: 'pm' }, end: { hour: 6, minute: 0, amPm: 'pm' }}, 
-      {start: { hour: 10, minute: 0, amPm: 'am' }, end: { hour: 5, minute: 0, amPm: 'pm' }}],
-      Wednesday: [],
-      Thursday: [],
-      Friday: [],
-      Saturday: [],
-    };
-  
-    const expectedOutput: AvailabilityJSON = {
-        Sunday: [],
-        Monday: [],
-        Tuesday: [{start: { hour: 3, minute: 0, amPm: 'pm' }, end: { hour: 6, minute: 0, amPm: 'pm' }}, 
-        {start: { hour: 10, minute: 0, amPm: 'am' }, end: { hour: 5, minute: 0, amPm: 'pm' }}],
-        Wednesday: [],
-        Thursday: [],
-        Friday: [],
-        Saturday: [],
-    };
-  
-    const result = validateNoOverlap(input);
-  
-    assertEquals(result, expectedOutput);
-  });
+Deno.test('validateNoOverlap should return overlapping times for partially overlapping time slots', () => {
+  const input: AvailabilityJSON = {
+    Sunday: [],
+    Monday: [],
+    Tuesday: [{
+      start: { hour: 3, minute: 0, amPm: 'pm' },
+      end: { hour: 6, minute: 0, amPm: 'pm' },
+    }, {
+      start: { hour: 10, minute: 0, amPm: 'am' },
+      end: { hour: 5, minute: 0, amPm: 'pm' },
+    }],
+    Wednesday: [],
+    Thursday: [],
+    Friday: [],
+    Saturday: [],
+  }
 
-  //overlap : partially pattern 3 (10am-3pm and 11am-2pm)
+  const expectedOutput: AvailabilityJSON = {
+    Sunday: [],
+    Monday: [],
+    Tuesday: [{
+      start: { hour: 3, minute: 0, amPm: 'pm' },
+      end: { hour: 6, minute: 0, amPm: 'pm' },
+    }, {
+      start: { hour: 10, minute: 0, amPm: 'am' },
+      end: { hour: 5, minute: 0, amPm: 'pm' },
+    }],
+    Wednesday: [],
+    Thursday: [],
+    Friday: [],
+    Saturday: [],
+  }
 
-  Deno.test("validateNoOverlap should return overlapping times for partially overlapping time slots", () => {
-    const input: AvailabilityJSON = {
-      Sunday: [],
-      Monday: [],
-      Tuesday: [{start: { hour: 10, minute: 0, amPm: 'am' }, end: { hour: 3, minute: 0, amPm: 'pm' }}, 
-      {start: { hour: 11, minute: 0, amPm: 'am' }, end: { hour: 2, minute: 0, amPm: 'pm' }}],
-      Wednesday: [],
-      Thursday: [],
-      Friday: [],
-      Saturday: [],
-    };
-  
-    const expectedOutput: AvailabilityJSON = {
-        Sunday: [],
-        Monday: [],
-        Tuesday: [{start: { hour: 10, minute: 0, amPm: 'am' }, end: { hour: 3, minute: 0, amPm: 'pm' }}, 
-        {start: { hour: 11, minute: 0, amPm: 'am' }, end: { hour: 2, minute: 0, amPm: 'pm' }}],
-        Wednesday: [],
-        Thursday: [],
-        Friday: [],
-        Saturday: [],
-    };
-  
-    const result = validateNoOverlap(input);
+  const result = validateNoOverlap(input)
 
-    assertEquals(result, expectedOutput);
-  });
+  assertEquals(result, expectedOutput)
+})
 
-  //ovelap : completely same time
-  Deno.test("validateNoOverlap should return overlapping times for partially overlapping time slots", () => {
-    const input: AvailabilityJSON = {
-      Sunday: [],
-      Monday: [],
-      Tuesday: [],
-      Wednesday: [],
-      Thursday: [],
-      Friday: [],
-      Saturday: [{start: { hour: 10, minute: 0, amPm: 'am' }, end: { hour: 11, minute: 0, amPm: 'am' }}, 
-      {start: { hour: 10, minute: 0, amPm: 'am' }, end: { hour: 11, minute: 0, amPm: 'am' }}],
-    };
-  
-    const expectedOutput: AvailabilityJSON = {
-        Sunday: [],
-        Monday: [],
-        Tuesday: [],
-        Wednesday: [],
-        Thursday: [],
-        Friday: [],
-        Saturday: [{start: { hour: 10, minute: 0, amPm: 'am' }, end: { hour: 11, minute: 0, amPm: 'am' }}, 
-        {start: { hour: 10, minute: 0, amPm: 'am' }, end: { hour: 11, minute: 0, amPm: 'am' }}],
-    };
-  
-    const result = validateNoOverlap(input);
-  
-    assertEquals(result, expectedOutput);
-  });
+//overlap : partially pattern 3 (10am-3pm and 11am-2pm)
 
-  
+Deno.test('validateNoOverlap should return overlapping times for partially overlapping time slots', () => {
+  const input: AvailabilityJSON = {
+    Sunday: [],
+    Monday: [],
+    Tuesday: [{
+      start: { hour: 10, minute: 0, amPm: 'am' },
+      end: { hour: 3, minute: 0, amPm: 'pm' },
+    }, {
+      start: { hour: 11, minute: 0, amPm: 'am' },
+      end: { hour: 2, minute: 0, amPm: 'pm' },
+    }],
+    Wednesday: [],
+    Thursday: [],
+    Friday: [],
+    Saturday: [],
+  }
+
+  const expectedOutput: AvailabilityJSON = {
+    Sunday: [],
+    Monday: [],
+    Tuesday: [{
+      start: { hour: 10, minute: 0, amPm: 'am' },
+      end: { hour: 3, minute: 0, amPm: 'pm' },
+    }, {
+      start: { hour: 11, minute: 0, amPm: 'am' },
+      end: { hour: 2, minute: 0, amPm: 'pm' },
+    }],
+    Wednesday: [],
+    Thursday: [],
+    Friday: [],
+    Saturday: [],
+  }
+
+  const result = validateNoOverlap(input)
+
+  assertEquals(result, expectedOutput)
+})
+
+//ovelap : completely same time
+Deno.test('validateNoOverlap should return overlapping times for partially overlapping time slots', () => {
+  const input: AvailabilityJSON = {
+    Sunday: [],
+    Monday: [],
+    Tuesday: [],
+    Wednesday: [],
+    Thursday: [],
+    Friday: [],
+    Saturday: [{
+      start: { hour: 10, minute: 0, amPm: 'am' },
+      end: { hour: 11, minute: 0, amPm: 'am' },
+    }, {
+      start: { hour: 10, minute: 0, amPm: 'am' },
+      end: { hour: 11, minute: 0, amPm: 'am' },
+    }],
+  }
+
+  const expectedOutput: AvailabilityJSON = {
+    Sunday: [],
+    Monday: [],
+    Tuesday: [],
+    Wednesday: [],
+    Thursday: [],
+    Friday: [],
+    Saturday: [{
+      start: { hour: 10, minute: 0, amPm: 'am' },
+      end: { hour: 11, minute: 0, amPm: 'am' },
+    }, {
+      start: { hour: 10, minute: 0, amPm: 'am' },
+      end: { hour: 11, minute: 0, amPm: 'am' },
+    }],
+  }
+
+  const result = validateNoOverlap(input)
+
+  assertEquals(result, expectedOutput)
+})


### PR DESCRIPTION
## Description

Feature to prevent availability form submission if times overlap, and to present the user with an error

Testing is under `test/overlap.test.ts`

## Showcase

![image](https://github.com/morehumaninternet/virtual-hospitals-africa/assets/36630598/4179e99f-be16-49e7-a5d7-27297804a902)

### Video
 
https://youtu.be/49gYBsTISqU

## Implementation

At a high level the form submission at `SetAvailabilityForm` in `islands/set-availability-form.tsx` is intercepted, and the `validateForm` function is called.

`validateForm` converts the form data into a `AvaliabilityJSON` (AJ) which is then piped to the `validateNoOverlap` function, doing it this way allows for further validation functions to be placed on top to do further checking in the future (if needed).

`validateNoOverlap` takes the form's AJ, then, for each day compares each time windows for overlap using the `overlaps` function. If any overlaps are found, the results are stored in a new AJ which is returned by `validateNoOverlap` or, if no overlapping times are found, returns null.

If the result !== null, then an error message is created (described in the `WarningModal` function), using the returned AJ

## Other notes

I have one concern about converting the form data into an `AJ`, in that it's already a step we do under `routes/api/set-availability.tsx` when the form is submitted. In this pull request we would be doing the same thing twice, I'm not sure how to implement this but would it be better to send the 'AJ' to the API instead of form data, thus eliminating the need for another conversion step?

Commits:
- onSubmit added to validate form before submitting Co-authored-by: Mike Huang <mike.huang.mikank@gmail.com>
- fixed overlap function
- Added modal to display overlapping message
- Uncomment functionality code
- debugging log added
- Integrated validation result to show modal
- warning modal integration
- write the unit test
- added comments
- deno fmt
