### PR TITLE
change logic of checking invalid date

### DIFF
--- a/util/date.ts
+++ b/util/date.ts
@@ -294,11 +294,14 @@ export function convertToTimeString(time: string): string {
 
 // TODO Implement this
 export function isValidDate(messageBody: string): boolean {
-  const [day, month, year] = messageBody.split('/')
+  const [d, m, y] = messageBody.split('/')
+  const year = `${y}`
+  const month = `${m}`.padStart(2, '0')
+  const day = `${d}`.padStart(2, '0')
   const date = new Date(
-    `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}T00:00:00Z`,
+    `${year}-${month}-${day}T00:00:00Z`,
   )
-  return !!date
+  return date.toDateString() !== 'Invalid Date'
 }
 
 export function getISOInHarare(date: Date) {


### PR DESCRIPTION
Previously when we are handling invalid date in the chatbot, user can get random error that is not understandable.
![IMG_D0539E298DEC-1](https://github.com/morehumaninternet/virtual-hospitals-africa/assets/90530544/5ebdf515-3cb7-4f4e-98b1-d6aca31d6cd5)

I changed the logic of isValidDate() to utilise Date object's toDateString to return 'Invalid Date' if it's out of the acceptable range.

So when user enter an invalid date, they will see the standard error message we got in the chatbot.
<img width="892" alt="image" src="https://github.com/morehumaninternet/virtual-hospitals-africa/assets/90530544/19a5bc81-5fac-49a5-964e-1265e250c984">
