### PR TITLE
use kysely-codegen

### DIFF
--- a/chatbot/patient/conversationStates.ts
+++ b/chatbot/patient/conversationStates.ts
@@ -211,9 +211,8 @@ const conversationStates: ConversationStates<
       }
 
       const facilities = nearest_facilities.map((facility) => {
-        const distanceInKM = facility.walking_distance
-          ? facility.walking_distance
-          : (facility.distance / 1000).toFixed(1) + ' km'
+        const distanceInKM = facility.walking_distance ||
+          (facility.distance / 1000).toFixed(1) + ' km'
         const description = distanceInKM
           ? `${facility.address} (${distanceInKM})`
           : facility.address

--- a/components/library/form/Inputs.tsx
+++ b/components/library/form/Inputs.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from 'preact/compat'
 import { MagnifyingGlassIcon } from '../icons/heroicons/outline.tsx'
 import capitalize from '../../../util/capitalize.ts'
 import cls from '../../../util/cls.ts'
-import { Ethnicity, Maybe, NURSE_SPECIALTIES } from '../../../types.ts'
+import { Maybe, NURSE_SPECIALTIES } from '../../../types.ts'
 
 type LabeledInputProps<El extends HTMLElement> = {
   name: string | null
@@ -567,7 +567,7 @@ export function GenderSelect(
 }
 
 export function EthnicitySelect(
-  { value }: { value: Maybe<Ethnicity> },
+  { value }: { value: Maybe<string> },
 ) {
   return (
     <Select
@@ -578,9 +578,9 @@ export function EthnicitySelect(
       <option value=''>Select</option>
       <option value='african' label='African' selected={value === 'african'} />
       <option
-        value='african_american'
+        value='african american'
         label='African American'
-        selected={value === 'african_american'}
+        selected={value === 'african american'}
       />
       <option value='asian' label='Asian' selected={value === 'asian'} />
       <option
@@ -599,19 +599,19 @@ export function EthnicitySelect(
         selected={value === 'hispanic'}
       />
       <option
-        value='middle_eastern'
+        value='middle eastern'
         label='Middle Eastern'
-        selected={value === 'middle_eastern'}
+        selected={value === 'middle eastern'}
       />
       <option
-        value='native_american'
+        value='native american'
         label='Native American'
-        selected={value === 'native_american'}
+        selected={value === 'native american'}
       />
       <option
-        value='pacific_islander'
+        value='pacific islander'
         label='Pacific Islander'
-        selected={value === 'pacific_islander'}
+        selected={value === 'pacific islander'}
       />
       <option value='other' label='Other' selected={value === 'other'} />
     </Select>

--- a/components/library/form/buttons.tsx
+++ b/components/library/form/buttons.tsx
@@ -1,3 +1,4 @@
+import { ComponentChildren } from 'https://esm.sh/v128/preact@10.19.2/src/index.js'
 import cls from '../../../util/cls.ts'
 import { Button } from '../Button.tsx'
 
@@ -10,6 +11,16 @@ type FormButtonsProps = {
   }
 }
 
+export function ButtonsContainer(
+  { className, children }: { className?: string; children: ComponentChildren },
+) {
+  return (
+    <div className={cls('container grid gap-x-2 grid-cols-2', className)}>
+      {children}
+    </div>
+  )
+}
+
 export default function FormButtons(
   {
     className,
@@ -18,7 +29,7 @@ export default function FormButtons(
   }: FormButtonsProps = {},
 ) {
   return (
-    <div className={cls('container grid gap-x-2 grid-cols-2', className)}>
+    <ButtonsContainer className={className}>
       {cancel && (
         <Button
           type='button'
@@ -30,6 +41,6 @@ export default function FormButtons(
         </Button>
       )}
       <Button type='submit'>{submitText}</Button>
-    </div>
+    </ButtonsContainer>
   )
 }

--- a/components/patients/intake/Review.tsx
+++ b/components/patients/intake/Review.tsx
@@ -10,7 +10,7 @@ export default function PatientReview(
   return (
     <div>
       <PatientDetailedCard patient={patient as any} />
-      <input type='hidden' name='completed_onboarding' value='on' />
+      <input type='hidden' name='completed_intake' value='on' />
     </div>
   )
 }

--- a/db.d.ts
+++ b/db.d.ts
@@ -1,0 +1,590 @@
+import type { ColumnType } from 'kysely'
+
+export type EncounterReason =
+  | 'appointment'
+  | 'checkup'
+  | 'emergency'
+  | 'follow up'
+  | 'other'
+  | 'referral'
+  | 'seeking treatment'
+
+export type Gender = 'female' | 'male' | 'other'
+
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>
+
+export type GuardianRelation =
+  | 'adopted parent'
+  | 'biological parent'
+  | 'foster parent'
+  | 'grandparent'
+  | 'other guardian'
+  | 'sibling'
+  | 'sibling of parent'
+
+export type HealthWorkerProfessions = 'admin' | 'doctor' | 'nurse'
+
+export type Json = ColumnType<JsonValue, string, string>
+
+export type JsonArray = JsonValue[]
+
+export type JsonObject = {
+  [K in string]?: JsonValue
+}
+
+export type JsonPrimitive = boolean | number | string | null
+
+export type JsonValue = JsonArray | JsonObject | JsonPrimitive
+
+export type Numeric = ColumnType<string, number | string, number | string>
+
+export type NurseSpecialty =
+  | 'anaesthetist'
+  | 'clinical care'
+  | 'clinical officer'
+  | 'community'
+  | 'dental'
+  | 'intensive and coronary care'
+  | 'midwife'
+  | 'neonatal intensive care and paediatric'
+  | 'oncology and palliative care'
+  | 'operating theatre'
+  | 'opthalmic'
+  | 'orthopaedic'
+  | 'primary care'
+  | 'psychiatric mental health'
+  | 'registered general'
+  | 'renal'
+  | 'trauma care'
+
+export type PatientConversationState =
+  | 'find_nearest_facility:got_location'
+  | 'find_nearest_facility:send_facility_location'
+  | 'find_nearest_facility:share_location'
+  | 'initial_message'
+  | 'not_onboarded:make_appointment:enter_date_of_birth'
+  | 'not_onboarded:make_appointment:enter_gender'
+  | 'not_onboarded:make_appointment:enter_name'
+  | 'not_onboarded:make_appointment:enter_national_id_number'
+  | 'not_onboarded:welcome'
+  | 'onboarded:appointment_scheduled'
+  | 'onboarded:cancel_appointment'
+  | 'onboarded:main_menu'
+  | 'onboarded:make_appointment:confirm_details'
+  | 'onboarded:make_appointment:enter_appointment_reason'
+  | 'onboarded:make_appointment:first_scheduling_option'
+  | 'onboarded:make_appointment:initial_ask_for_media'
+  | 'onboarded:make_appointment:other_scheduling_options'
+  | 'onboarded:make_appointment:subsequent_ask_for_media'
+  | 'other_end_of_demo'
+
+export type Timestamp = ColumnType<Date, Date | string, Date | string>
+
+export interface Address {
+  country_id: number
+  created_at: Generated<Timestamp>
+  district_id: number
+  id: Generated<number>
+  province_id: number
+  street: string | null
+  suburb_id: number | null
+  updated_at: Generated<Timestamp>
+  ward_id: number
+}
+
+export interface Allergies {
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  name: string
+  updated_at: Generated<Timestamp>
+}
+
+export interface AppointmentHealthWorkerAttendees {
+  appointment_id: number
+  confirmed: Generated<boolean>
+  created_at: Generated<Timestamp>
+  health_worker_id: number
+  id: Generated<number>
+  updated_at: Generated<Timestamp>
+}
+
+export interface AppointmentMedia {
+  appointment_id: number
+  media_id: number
+}
+
+export interface Appointments {
+  created_at: Generated<Timestamp>
+  gcal_event_id: string
+  id: Generated<number>
+  patient_id: number
+  reason: string
+  start: Timestamp
+  updated_at: Generated<Timestamp>
+}
+
+export interface ConditionIcd10Codes {
+  condition_key_id: string
+  created_at: Generated<Timestamp>
+  icd10_code: string
+  updated_at: Generated<Timestamp>
+}
+
+export interface Conditions {
+  consumer_name: string
+  created_at: Generated<Timestamp>
+  info_link_href: string | null
+  info_link_text: string | null
+  is_procedure: boolean
+  key_id: string
+  primary_name: string
+  term_icd9_code: string | null
+  term_icd9_text: string | null
+  updated_at: Generated<Timestamp>
+}
+
+export interface Countries {
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  name: string
+  updated_at: Generated<Timestamp>
+}
+
+export interface Districts {
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  name: string
+  province_id: number
+  updated_at: Generated<Timestamp>
+}
+
+export interface Drugs {
+  created_at: Generated<Timestamp>
+  generic_name: string
+  id: Generated<number>
+  updated_at: Generated<Timestamp>
+}
+
+export interface Employment {
+  created_at: Generated<Timestamp>
+  facility_id: number
+  health_worker_id: number
+  id: Generated<number>
+  profession: HealthWorkerProfessions
+  updated_at: Generated<Timestamp>
+}
+
+export interface Facilities {
+  address: string
+  category: string
+  created_at: Generated<Timestamp>
+  display_name: Generated<string>
+  id: Generated<number>
+  location: string
+  name: string
+  phone: string | null
+  updated_at: Generated<Timestamp>
+}
+
+export interface GeographyColumns {
+  coord_dimension: number | null
+  f_geography_column: string | null
+  f_table_catalog: string | null
+  f_table_name: string | null
+  f_table_schema: string | null
+  srid: number | null
+  type: string | null
+}
+
+export interface GeometryColumns {
+  coord_dimension: number | null
+  f_geometry_column: string | null
+  f_table_catalog: string | null
+  f_table_name: string | null
+  f_table_schema: string | null
+  srid: number | null
+  type: string | null
+}
+
+export interface GuardianRelations {
+  created_at: Generated<Timestamp>
+  dependent: string
+  female_dependent: string | null
+  female_guardian: string | null
+  guardian: GuardianRelation
+  male_dependent: string | null
+  male_guardian: string | null
+  updated_at: Generated<Timestamp>
+}
+
+export interface HealthWorkerGoogleTokens {
+  access_token: string
+  created_at: Generated<Timestamp>
+  expires_at: Timestamp
+  health_worker_id: number
+  id: Generated<number>
+  refresh_token: string
+  updated_at: Generated<Timestamp>
+}
+
+export interface HealthWorkerInvitees {
+  created_at: Generated<Timestamp>
+  email: string
+  facility_id: number
+  id: Generated<number>
+  profession: HealthWorkerProfessions
+  updated_at: Generated<Timestamp>
+}
+
+export interface HealthWorkers {
+  avatar_url: string
+  created_at: Generated<Timestamp>
+  email: string
+  gcal_appointments_calendar_id: string
+  gcal_availability_calendar_id: string
+  id: Generated<number>
+  name: string
+  updated_at: Generated<Timestamp>
+}
+
+export interface Icd10Codes {
+  code: string
+  created_at: Generated<Timestamp>
+  name: string
+  updated_at: Generated<Timestamp>
+}
+
+export interface MailingList {
+  created_at: Generated<Timestamp>
+  email: string
+  entrypoint: string
+  id: Generated<number>
+  interest: string | null
+  message: string | null
+  name: string
+  support: string | null
+  updated_at: Generated<Timestamp>
+}
+
+export interface ManufacturedMedications {
+  applicant_name: string
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  manufacturer_name: string
+  medication_id: number
+  strength_numerators: number[]
+  trade_name: string
+  updated_at: Generated<Timestamp>
+}
+
+export interface Measurements {
+  name: string
+  units: string
+}
+
+export interface Media {
+  binary_data: Buffer
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  mime_type: string
+  updated_at: Generated<Timestamp>
+}
+
+export interface Medications {
+  created_at: Generated<Timestamp>
+  drug_id: number
+  form: string
+  form_route: Generated<string>
+  id: Generated<number>
+  routes: string[]
+  strength_denominator: Numeric
+  strength_denominator_is_units: Generated<boolean>
+  strength_denominator_unit: string
+  strength_numerator_unit: string
+  strength_numerators: number[]
+  updated_at: Generated<Timestamp>
+}
+
+export interface NurseRegistrationDetails {
+  address_id: number | null
+  approved_by: number | null
+  created_at: Generated<Timestamp>
+  date_of_birth: Timestamp
+  date_of_first_practice: Timestamp
+  face_picture_media_id: number | null
+  gender: Gender
+  health_worker_id: number
+  id: Generated<number>
+  mobile_number: string
+  national_id_media_id: number | null
+  national_id_number: string
+  ncz_registration_card_media_id: number | null
+  ncz_registration_number: string
+  nurse_practicing_cert_media_id: number | null
+  updated_at: Generated<Timestamp>
+}
+
+export interface NurseSpecialties {
+  created_at: Generated<Timestamp>
+  employee_id: number
+  id: Generated<number>
+  specialty: NurseSpecialty
+  updated_at: Generated<Timestamp>
+}
+
+export interface PatientAge {
+  age: string | null
+  patient_id: number | null
+}
+
+export interface PatientAllergies {
+  allergy_id: number
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  patient_id: number
+  updated_at: Generated<Timestamp>
+}
+
+export interface PatientAppointmentOfferedTimes {
+  created_at: Generated<Timestamp>
+  declined: Generated<boolean | null>
+  health_worker_id: number
+  id: Generated<number>
+  patient_appointment_request_id: number
+  start: Timestamp
+  updated_at: Generated<Timestamp>
+}
+
+export interface PatientAppointmentRequestMedia {
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  media_id: number
+  patient_appointment_request_id: number
+  updated_at: Generated<Timestamp>
+}
+
+export interface PatientAppointmentRequests {
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  patient_id: number
+  reason: string | null
+  updated_at: Generated<Timestamp>
+}
+
+export interface PatientConditionMedications {
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  manufactured_medication_id: number | null
+  medication_id: number | null
+  patient_condition_id: number
+  route: string
+  schedules: string[] | null
+  special_instructions: string | null
+  start_date: Timestamp
+  strength: Numeric
+  updated_at: Generated<Timestamp>
+}
+
+export interface PatientConditions {
+  comorbidity_of_condition_id: number | null
+  condition_key_id: string
+  created_at: Generated<Timestamp>
+  end_date: Timestamp | null
+  id: Generated<number>
+  patient_id: number
+  start_date: Timestamp
+  updated_at: Generated<Timestamp>
+}
+
+export interface PatientEncounterProviders {
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  patient_encounter_id: number
+  provider_id: number | null
+  seen_at: Timestamp | null
+  updated_at: Generated<Timestamp>
+}
+
+export interface PatientEncounters {
+  appointment_id: number | null
+  closed_at: Timestamp | null
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  notes: string | null
+  patient_id: number
+  reason: EncounterReason
+  updated_at: Generated<Timestamp>
+}
+
+export interface PatientGuardians {
+  created_at: Generated<Timestamp>
+  dependent_patient_id: number
+  guardian_patient_id: number
+  guardian_relation: GuardianRelation
+  id: Generated<number>
+  updated_at: Generated<Timestamp>
+}
+
+export interface PatientMeasurements {
+  created_at: Generated<Timestamp>
+  encounter_id: number
+  encounter_provider_id: number
+  id: Generated<number>
+  measurement_name: string
+  patient_id: number
+  updated_at: Generated<Timestamp>
+  value: Numeric
+}
+
+export interface PatientNearestFacilities {
+  nearest_facilities: Json | null
+  patient_id: number | null
+}
+
+export interface PatientOccupations {
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  job: Json | null
+  patient_id: number
+  school: Json | null
+  updated_at: Generated<Timestamp>
+}
+
+export interface Patients {
+  address_id: number | null
+  avatar_media_id: number | null
+  completed_intake: Generated<boolean>
+  conversation_state: Generated<PatientConversationState>
+  created_at: Generated<Timestamp>
+  date_of_birth: Timestamp | null
+  ethnicity: string | null
+  gender: Gender | null
+  id: Generated<number>
+  location: string | null
+  name: string | null
+  national_id_number: string | null
+  nearest_facility_id: number | null
+  phone_number: string | null
+  primary_doctor_id: number | null
+  unregistered_primary_doctor_name: string | null
+  updated_at: Generated<Timestamp>
+}
+
+export interface Provinces {
+  country_id: number
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  name: string
+  updated_at: Generated<Timestamp>
+}
+
+export interface SpatialRefSys {
+  auth_name: string | null
+  auth_srid: number | null
+  proj4text: string | null
+  srid: number
+  srtext: string | null
+}
+
+export interface Suburbs {
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  name: string
+  updated_at: Generated<Timestamp>
+  ward_id: number
+}
+
+export interface WaitingRoom {
+  created_at: Generated<Timestamp>
+  facility_id: number
+  id: Generated<number>
+  patient_encounter_id: number
+  updated_at: Generated<Timestamp>
+}
+
+export interface Wards {
+  created_at: Generated<Timestamp>
+  district_id: number
+  id: Generated<number>
+  name: string
+  updated_at: Generated<Timestamp>
+}
+
+export interface WhatsappMessagesReceived {
+  body: string | null
+  conversation_state: Generated<PatientConversationState>
+  created_at: Generated<Timestamp>
+  error_commit_hash: string | null
+  error_message: string | null
+  has_media: Generated<boolean>
+  id: Generated<number>
+  media_id: number | null
+  patient_id: number
+  started_responding_at: Timestamp | null
+  updated_at: Generated<Timestamp>
+  whatsapp_id: string
+}
+
+export interface WhatsappMessagesSent {
+  body: string
+  created_at: Generated<Timestamp>
+  id: Generated<number>
+  patient_id: number
+  read_status: string
+  responding_to_id: number
+  updated_at: Generated<Timestamp>
+  whatsapp_id: string
+}
+
+export interface DB {
+  address: Address
+  allergies: Allergies
+  appointment_health_worker_attendees: AppointmentHealthWorkerAttendees
+  appointment_media: AppointmentMedia
+  appointments: Appointments
+  condition_icd10_codes: ConditionIcd10Codes
+  conditions: Conditions
+  countries: Countries
+  districts: Districts
+  drugs: Drugs
+  employment: Employment
+  facilities: Facilities
+  geography_columns: GeographyColumns
+  geometry_columns: GeometryColumns
+  guardian_relations: GuardianRelations
+  health_worker_google_tokens: HealthWorkerGoogleTokens
+  health_worker_invitees: HealthWorkerInvitees
+  health_workers: HealthWorkers
+  icd10_codes: Icd10Codes
+  mailing_list: MailingList
+  manufactured_medications: ManufacturedMedications
+  measurements: Measurements
+  media: Media
+  medications: Medications
+  nurse_registration_details: NurseRegistrationDetails
+  nurse_specialties: NurseSpecialties
+  patient_age: PatientAge
+  patient_allergies: PatientAllergies
+  patient_appointment_offered_times: PatientAppointmentOfferedTimes
+  patient_appointment_request_media: PatientAppointmentRequestMedia
+  patient_appointment_requests: PatientAppointmentRequests
+  patient_condition_medications: PatientConditionMedications
+  patient_conditions: PatientConditions
+  patient_encounter_providers: PatientEncounterProviders
+  patient_encounters: PatientEncounters
+  patient_guardians: PatientGuardians
+  patient_measurements: PatientMeasurements
+  patient_nearest_facilities: PatientNearestFacilities
+  patient_occupations: PatientOccupations
+  patients: Patients
+  provinces: Provinces
+  spatial_ref_sys: SpatialRefSys
+  suburbs: Suburbs
+  waiting_room: WaitingRoom
+  wards: Wards
+  whatsapp_messages_received: WhatsappMessagesReceived
+  whatsapp_messages_sent: WhatsappMessagesSent
+}
+type Buffer = Uint8Array

--- a/db/codegen/package.json
+++ b/db/codegen/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "codegen",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "kysely-codegen": "^0.11.0",
+    "pg": "^8.11.3"
+  }
+}

--- a/db/migrations/20230126000000_patients.ts
+++ b/db/migrations/20230126000000_patients.ts
@@ -47,7 +47,7 @@ export async function up(db: Kysely<unknown>) {
     .addColumn(
       'conversation_state',
       sql`patient_conversation_state`,
-      (column) => column.defaultTo('initial_message'),
+      (column) => column.notNull().defaultTo('initial_message'),
     )
     .addUniqueConstraint('patient_national_id_number', ['national_id_number'])
     .addUniqueConstraint('patient_phone_number', ['phone_number'])

--- a/db/migrations/20230127024002_whatsapp_conversation.ts
+++ b/db/migrations/20230127024002_whatsapp_conversation.ts
@@ -45,7 +45,7 @@ export async function up(db: Kysely<unknown>) {
     .addColumn(
       'conversation_state',
       sql`patient_conversation_state`,
-      (col) => col.defaultTo('initial_message'),
+      (col) => col.notNull().defaultTo('initial_message'),
     )
     .execute()
 

--- a/db/migrations/20230127203321_health_workers.ts
+++ b/db/migrations/20230127203321_health_workers.ts
@@ -18,8 +18,16 @@ export async function up(db: Kysely<unknown>) {
     .addColumn('name', 'varchar(255)', (col) => col.notNull())
     .addColumn('email', 'varchar(255)', (col) => col.notNull())
     .addColumn('avatar_url', 'text', (col) => col.notNull())
-    .addColumn('gcal_appointments_calendar_id', 'varchar(255)')
-    .addColumn('gcal_availability_calendar_id', 'varchar(255)')
+    .addColumn(
+      'gcal_appointments_calendar_id',
+      'varchar(255)',
+      (col) => col.notNull(),
+    )
+    .addColumn(
+      'gcal_availability_calendar_id',
+      'varchar(255)',
+      (col) => col.notNull(),
+    )
     .addUniqueConstraint('health_worker_email', ['email'])
     .execute()
 

--- a/db/migrations/20230713162700_add_media_constraint.ts
+++ b/db/migrations/20230713162700_add_media_constraint.ts
@@ -6,7 +6,7 @@ export async function up(db: Kysely<any>) {
     .addColumn(
       'has_media',
       'boolean',
-      (col) => col.defaultTo(false),
+      (col) => col.notNull().defaultTo(false),
     )
     .addColumn(
       'media_id',

--- a/db/migrations/20230721132340_add_appointment_request_media.ts
+++ b/db/migrations/20230721132340_add_appointment_request_media.ts
@@ -19,12 +19,14 @@ export async function up(db: Kysely<unknown>) {
       'patient_appointment_request_id',
       'integer',
       (col) =>
-        col.references('patient_appointment_requests.id').onDelete('cascade'),
+        col.notNull().references('patient_appointment_requests.id').onDelete(
+          'cascade',
+        ),
     )
     .addColumn(
       'media_id',
       'integer',
-      (col) => col.references('media.id').onDelete('cascade'),
+      (col) => col.notNull().references('media.id').onDelete('cascade'),
     )
     .execute()
 
@@ -32,12 +34,12 @@ export async function up(db: Kysely<unknown>) {
     .addColumn(
       'appointment_id',
       'integer',
-      (col) => col.references('appointments.id').onDelete('cascade'),
+      (col) => col.notNull().references('appointments.id').onDelete('cascade'),
     )
     .addColumn(
       'media_id',
       'integer',
-      (col) => col.references('media.id').onDelete('cascade'),
+      (col) => col.notNull().references('media.id').onDelete('cascade'),
     )
     .execute()
 }

--- a/db/migrations/20231024212547_patient_completed_onboarding.ts
+++ b/db/migrations/20231024212547_patient_completed_onboarding.ts
@@ -3,13 +3,17 @@ import { Kysely } from 'kysely'
 export function up(db: Kysely<unknown>) {
   return db.schema
     .alterTable('patients')
-    .addColumn('completed_onboarding', 'boolean', (col) => col.defaultTo(false))
+    .addColumn(
+      'completed_intake',
+      'boolean',
+      (col) => col.notNull().defaultTo(false),
+    )
     .execute()
 }
 
 export function down(db: Kysely<unknown>) {
   return db.schema
     .alterTable('patients')
-    .dropColumn('completed_onboarding')
+    .dropColumn('completed_intake')
     .execute()
 }

--- a/db/migrations/20231026014542_add-facility-display-name.ts
+++ b/db/migrations/20231026014542_add-facility-display-name.ts
@@ -4,7 +4,7 @@ import * as patient_nearest_facilities_migration from './20230629185250_patient_
 
 export async function up(db: Kysely<any>) {
   await sql`
-    ALTER TABLE facilities ADD display_name TEXT GENERATED ALWAYS AS (name || ' ' || INITCAP(category)) STORED
+    ALTER TABLE facilities ADD display_name TEXT NOT NULL GENERATED ALWAYS AS (name || ' ' || INITCAP(category)) STORED
   `.execute(db)
 
   await db.updateTable('facilities')

--- a/db/migrations/20231113120321_add_address_table.ts
+++ b/db/migrations/20231113120321_add_address_table.ts
@@ -1,9 +1,20 @@
-import { Kysely } from 'kysely'
+import { Kysely, sql } from 'kysely'
+import { addUpdatedAtTrigger } from '../addUpdatedAtTrigger.ts'
 
 export async function up(db: Kysely<unknown>) {
   await db.schema
     .createTable('address')
     .addColumn('id', 'serial', (col) => col.primaryKey())
+    .addColumn(
+      'created_at',
+      'timestamp',
+      (col) => col.defaultTo(sql`now()`).notNull(),
+    )
+    .addColumn(
+      'updated_at',
+      'timestamp',
+      (col) => col.defaultTo(sql`now()`).notNull(),
+    )
     .addColumn('street', 'varchar(255)')
     .addColumn('suburb_id', 'integer', (col) => col.references('suburbs.id'))
     .addColumn('ward_id', 'integer', (col) =>
@@ -35,6 +46,8 @@ export async function up(db: Kysely<unknown>) {
     .dropColumn('country_id')
     .addColumn('address_id', 'integer', (col) => col.references('address.id'))
     .execute()
+
+  await addUpdatedAtTrigger(db, 'address')
 }
 
 export async function down(db: Kysely<unknown>) {

--- a/db/migrations/20231129161929_medications_tables.ts
+++ b/db/migrations/20231129161929_medications_tables.ts
@@ -68,7 +68,7 @@ export async function up(db: Kysely<unknown>) {
 
   await sql`
     ALTER TABLE medications
-    ADD form_route TEXT
+    ADD form_route TEXT NOT NULL
     GENERATED ALWAYS AS (
       form || (
         CASE WHEN array_length(routes, 1) = 1 
@@ -81,7 +81,7 @@ export async function up(db: Kysely<unknown>) {
 
   await sql`
     ALTER TABLE medications
-    ADD strength_denominator_is_units BOOLEAN
+    ADD strength_denominator_is_units BOOLEAN NOT NULL
     GENERATED ALWAYS AS (
       strength_denominator_unit IN ('MG', 'G', 'ML', 'L', 'MCG', 'UG', 'IU')
     )

--- a/db/migrations/20231207211637_family.ts
+++ b/db/migrations/20231207211637_family.ts
@@ -5,8 +5,13 @@ import { GUARDIAN_RELATIONS } from '../../shared/family.ts'
 // deno-lint-ignore no-explicit-any
 export async function up(db: Kysely<any>) {
   await db.schema
+    .createType('guardian_relation')
+    .asEnum(GUARDIAN_RELATIONS.map(({ guardian }) => guardian))
+    .execute()
+
+  await db.schema
     .createTable('guardian_relations')
-    .addColumn('guardian', 'varchar(255)', (col) => col.primaryKey())
+    .addColumn('guardian', sql`guardian_relation`, (col) => col.primaryKey())
     .addColumn('dependent', 'varchar(255)', (col) => col.notNull())
     .addColumn('female_guardian', 'varchar(255)')
     .addColumn('male_guardian', 'varchar(255)')
@@ -39,7 +44,7 @@ export async function up(db: Kysely<any>) {
     )
     .addColumn(
       'guardian_relation',
-      'varchar(255)',
+      sql`guardian_relation`,
       (col) =>
         col.notNull().references('guardian_relations.guardian').onDelete(
           'cascade',
@@ -76,4 +81,5 @@ export async function up(db: Kysely<any>) {
 export async function down(db: Kysely<unknown>) {
   await db.schema.dropTable('patient_guardians').execute()
   await db.schema.dropTable('guardian_relations').execute()
+  await db.schema.dropType('guardian_relation').execute()
 }

--- a/db/models/appointments.ts
+++ b/db/models/appointments.ts
@@ -1,7 +1,6 @@
 import { sql } from 'kysely'
 import {
   Appointment,
-  AppointmentMedia,
   AppointmentWithAllPatientInfo,
   Maybe,
   NonNull,
@@ -103,8 +102,8 @@ export function upsert(
 
 export function upsertRequest(
   trx: TrxOrDb,
-  info: PatientAppointmentRequest & { id?: number },
-): Promise<Maybe<ReturnedSqlRow<PatientAppointmentRequest>>> {
+  info: { id?: number; patient_id: number; reason?: string | null },
+): Promise<ReturnedSqlRow<PatientAppointmentRequest>> {
   return trx
     .insertInto('patient_appointment_requests')
     .values(info)
@@ -320,7 +319,7 @@ export function insertMedia(
     appointment_id: number
     media_ids: number[]
   },
-): Promise<ReturnedSqlRow<AppointmentMedia>> {
+) {
   assert(opts.appointment_id)
   assert(opts.media_ids.length)
   const toInsert = opts.media_ids.map((media_id) => ({

--- a/db/models/conversations.ts
+++ b/db/models/conversations.ts
@@ -60,7 +60,7 @@ export async function insertMessageReceived(
     .values({
       phone_number: patient_phone_number,
       conversation_state: 'initial_message',
-      completed_onboarding: false,
+      completed_intake: false,
     })
     .onConflict((oc) => oc.column('phone_number').doNothing())
     .returningAll()

--- a/db/models/facilities.ts
+++ b/db/models/facilities.ts
@@ -68,12 +68,23 @@ export function get(
   opts: {
     ids: number[]
   },
-) {
+): Promise<ReturnedSqlRow<Facility>[]> {
   assert(opts.ids.length, 'Must select nonzero facilities')
   return trx
     .selectFrom('facilities')
     .where('id', 'in', opts.ids)
-    .selectAll()
+    .select([
+      'id',
+      'created_at',
+      'updated_at',
+      'name',
+      'address',
+      'category',
+      'phone',
+      'display_name',
+      sql<number>`ST_X(location::geometry)`.as('longitude'),
+      sql<number>`ST_Y(location::geometry)`.as('latitude'),
+    ])
     .execute()
 }
 

--- a/db/models/family.ts
+++ b/db/models/family.ts
@@ -1,3 +1,4 @@
+import { sql } from 'kysely'
 import {
   FamilyRelationInsert,
   FamilyUpsert,
@@ -74,7 +75,7 @@ export async function get(
           ]),
         )
         .then(eb.ref('guardian_relations.male_guardian'))
-        .else(eb.ref('guardian_relations.guardian'))
+        .else(sql<string>`guardian_relations.guardian::text`)
         .end()
         .as('family_relation_gendered'),
     ])

--- a/db/models/media.ts
+++ b/db/models/media.ts
@@ -4,7 +4,8 @@ export function insert(
   trx: TrxOrDb,
   opts: { binary_data: Uint8Array; mime_type: string },
 ): Promise<ReturnedSqlRow<PatientMedia>> {
-  return trx.insertInto('media').values(opts).returningAll()
+  // deno-lint-ignore no-explicit-any
+  return trx.insertInto('media').values(opts as any).returningAll()
     .executeTakeFirstOrThrow()
 }
 

--- a/db/models/patient_conditions.ts
+++ b/db/models/patient_conditions.ts
@@ -1,4 +1,4 @@
-import { RawBuilder, sql } from 'kysely'
+import { sql } from 'kysely'
 import {
   Maybe,
   MedicationSchedule,
@@ -283,11 +283,11 @@ async function upsertPreExistingCondition(
         null,
       strength: medication.strength,
       route: medication.route,
-      schedules: sql`
+      schedules: sql<string[]>`
         ARRAY[
           ROW(${medication.dosage}, ${medication.intake_frequency}, ${duration}, ${duration_unit})
         ]::medication_schedule[]
-      ` as RawBuilder<MedicationSchedule[]>,
+      `,
       start_date,
       special_instructions: medication.special_instructions || null,
     }

--- a/db/models/waiting_room.ts
+++ b/db/models/waiting_room.ts
@@ -57,12 +57,12 @@ export async function get(
       jsonBuildObject({
         view_href: eb.case()
           .when(
-            eb('patients.completed_onboarding', '=', true),
+            eb('patients.completed_intake', '=', true),
           ).then(sql<string>`concat('/app/patients/', patients.id::text)`)
           .else(null).end(),
         intake_href: eb.case()
           .when(
-            eb('patients.completed_onboarding', '=', false),
+            eb('patients.completed_intake', '=', false),
           ).then(
             sql<
               string

--- a/deno.json
+++ b/deno.json
@@ -6,6 +6,7 @@
     "start": "deno task run:trusted --watch=chatbot/,db/,islands/,util/,components/,external-clients/,routes/,static/,shared/ dev.ts",
     "rebuild": "rm -rf /_fresh && rm -rf node_modules && deno task lock:reset && deno task build",
     "web": "deno task run:trusted main.ts",
+    "db:codegen": "cd ./db/codegen && npm install && cd ../.. && ./db/codegen/node_modules/.bin/kysely-codegen --out-file db.d.ts && echo 'type Buffer = Uint8Array' >> db.d.ts",
     "db:migrate:create": "deno task run:trusted db/create-migration.ts",
     "db:migrate:up": "deno task run:trusted db/migrate.ts --up",
     "db:migrate:latest": "deno task run:trusted db/migrate.ts --latest",
@@ -34,7 +35,7 @@
     "test": "DENO_TLS_CA_STORE=system IS_TEST=true deno test -A --unsafely-ignore-certificate-errors",
     "test:chatbot": "deno task test test/chatbot/patient/*.test.ts",
     "preview": "deno run -A main.ts",
-    "check": "deno fmt --check && deno lint && deno check **/*.ts && deno check **/*.tsx",
+    "check": "deno fmt --check && deno lint && find . -name '*.ts' -o -name '*.tsx' | grep -v node_modules | xargs deno check",
     "cli": "echo \"import '\\$fresh/src/dev/cli.ts'\" | deno run --unstable -A -",
     "manifest": "deno task cli manifest $(pwd)"
   },

--- a/deno.lock
+++ b/deno.lock
@@ -5,12 +5,19 @@
       "npm:@tailwindcss/forms@0.5.7": "npm:@tailwindcss/forms@0.5.7_tailwindcss@3.3.5__postcss@8.4.31",
       "npm:@types/node": "npm:@types/node@18.16.19",
       "npm:autoprefixer@10.4.16": "npm:autoprefixer@10.4.16_postcss@8.4.31",
+      "npm:autoprefixer@^10.4.16": "npm:autoprefixer@10.4.16_postcss@8.4.31",
       "npm:bluebird": "npm:bluebird@3.7.2",
       "npm:bluebird@3.7.2": "npm:bluebird@3.7.2",
+      "npm:bluebird@^3.7.2": "npm:bluebird@3.7.2",
       "npm:cssnano@6.0.1": "npm:cssnano@6.0.1_postcss@8.4.31",
+      "npm:cssnano@^6.0.1": "npm:cssnano@6.0.1_postcss@8.4.31",
+      "npm:kysely-codegen@^0.11.0": "npm:kysely-codegen@0.11.0_kysely@0.27.1",
       "npm:postcss@8.4.31": "npm:postcss@8.4.31",
+      "npm:postcss@^8.4.31": "npm:postcss@8.4.31",
       "npm:sinon": "npm:sinon@17.0.1",
-      "npm:tailwindcss@3.3.5": "npm:tailwindcss@3.3.5_postcss@8.4.31"
+      "npm:sinon@^17.0.1": "npm:sinon@17.0.1",
+      "npm:tailwindcss@3.3.5": "npm:tailwindcss@3.3.5_postcss@8.4.31",
+      "npm:tailwindcss@^3.3.5": "npm:tailwindcss@3.3.5_postcss@8.4.31"
     },
     "npm": {
       "@alloc/quick-lru@5.2.0": {
@@ -136,6 +143,12 @@
         "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
         "dependencies": {}
       },
+      "ansi-styles@3.2.1": {
+        "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+        "dependencies": {
+          "color-convert": "color-convert@1.9.3"
+        }
+      },
       "ansi-styles@4.3.0": {
         "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
         "dependencies": {
@@ -189,6 +202,13 @@
         "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
         "dependencies": {}
       },
+      "brace-expansion@1.1.11": {
+        "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+        "dependencies": {
+          "balanced-match": "balanced-match@1.0.2",
+          "concat-map": "concat-map@0.0.1"
+        }
+      },
       "brace-expansion@2.0.1": {
         "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
         "dependencies": {
@@ -227,6 +247,21 @@
         "integrity": "sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw==",
         "dependencies": {}
       },
+      "chalk@2.4.2": {
+        "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+        "dependencies": {
+          "ansi-styles": "ansi-styles@3.2.1",
+          "escape-string-regexp": "escape-string-regexp@1.0.5",
+          "supports-color": "supports-color@5.5.0"
+        }
+      },
+      "chalk@4.1.2": {
+        "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+        "dependencies": {
+          "ansi-styles": "ansi-styles@4.3.0",
+          "supports-color": "supports-color@7.2.0"
+        }
+      },
       "chokidar@3.5.3": {
         "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
         "dependencies": {
@@ -240,11 +275,21 @@
           "readdirp": "readdirp@3.6.0"
         }
       },
+      "color-convert@1.9.3": {
+        "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+        "dependencies": {
+          "color-name": "color-name@1.1.3"
+        }
+      },
       "color-convert@2.0.1": {
         "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
         "dependencies": {
           "color-name": "color-name@1.1.4"
         }
+      },
+      "color-name@1.1.3": {
+        "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+        "dependencies": {}
       },
       "color-name@1.1.4": {
         "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
@@ -260,6 +305,10 @@
       },
       "commander@7.2.0": {
         "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+        "dependencies": {}
+      },
+      "concat-map@0.0.1": {
+        "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
         "dependencies": {}
       },
       "cross-spawn@7.0.3": {
@@ -367,6 +416,10 @@
         "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
         "dependencies": {}
       },
+      "diff@3.5.0": {
+        "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+        "dependencies": {}
+      },
       "diff@5.1.0": {
         "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
         "dependencies": {}
@@ -401,6 +454,10 @@
           "domhandler": "domhandler@5.0.3"
         }
       },
+      "dotenv@16.3.1": {
+        "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+        "dependencies": {}
+      },
       "eastasianwidth@0.2.0": {
         "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
         "dependencies": {}
@@ -423,6 +480,10 @@
       },
       "escalade@3.1.1": {
         "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+        "dependencies": {}
+      },
+      "escape-string-regexp@1.0.5": {
+        "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
         "dependencies": {}
       },
       "fast-glob@3.3.2": {
@@ -458,6 +519,10 @@
         "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
         "dependencies": {}
       },
+      "fs.realpath@1.0.0": {
+        "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+        "dependencies": {}
+      },
       "fsevents@2.3.3": {
         "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
         "dependencies": {}
@@ -465,6 +530,16 @@
       "function-bind@1.1.2": {
         "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
         "dependencies": {}
+      },
+      "git-diff@2.0.6": {
+        "integrity": "sha512-/Iu4prUrydE3Pb3lCBMbcSNIf81tgGt0W1ZwknnyF62t3tHmtiJTRj0f+1ZIhp3+Rh0ktz1pJVoa7ZXUCskivA==",
+        "dependencies": {
+          "chalk": "chalk@2.4.2",
+          "diff": "diff@3.5.0",
+          "loglevel": "loglevel@1.8.1",
+          "shelljs": "shelljs@0.8.5",
+          "shelljs.exec": "shelljs.exec@1.1.8"
+        }
       },
       "glob-parent@5.1.2": {
         "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
@@ -488,6 +563,21 @@
           "path-scurry": "path-scurry@1.10.1"
         }
       },
+      "glob@7.2.3": {
+        "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+        "dependencies": {
+          "fs.realpath": "fs.realpath@1.0.0",
+          "inflight": "inflight@1.0.6",
+          "inherits": "inherits@2.0.4",
+          "minimatch": "minimatch@3.1.2",
+          "once": "once@1.4.0",
+          "path-is-absolute": "path-is-absolute@1.0.1"
+        }
+      },
+      "has-flag@3.0.0": {
+        "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+        "dependencies": {}
+      },
       "has-flag@4.0.0": {
         "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
         "dependencies": {}
@@ -497,6 +587,21 @@
         "dependencies": {
           "function-bind": "function-bind@1.1.2"
         }
+      },
+      "inflight@1.0.6": {
+        "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+        "dependencies": {
+          "once": "once@1.4.0",
+          "wrappy": "wrappy@1.0.2"
+        }
+      },
+      "inherits@2.0.4": {
+        "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+        "dependencies": {}
+      },
+      "interpret@1.4.0": {
+        "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+        "dependencies": {}
       },
       "is-binary-path@2.1.0": {
         "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
@@ -551,6 +656,21 @@
         "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
         "dependencies": {}
       },
+      "kysely-codegen@0.11.0_kysely@0.27.1": {
+        "integrity": "sha512-8aklzXygjANshk5BoGSQ0BWukKIoPL4/k1iFWyteGUQ/VtB1GlyrELBZv1GglydjLGECSSVDpsOgEXyWQmuksg==",
+        "dependencies": {
+          "chalk": "chalk@4.1.2",
+          "dotenv": "dotenv@16.3.1",
+          "git-diff": "git-diff@2.0.6",
+          "kysely": "kysely@0.27.1",
+          "micromatch": "micromatch@4.0.5",
+          "minimist": "minimist@1.2.8"
+        }
+      },
+      "kysely@0.27.1": {
+        "integrity": "sha512-X8IRdOYstCH0JmZVq9yk48QtmM5HULWQ3O6zy+G6olEUniV26voSGiZ+L4sJvNGQPiy/I9svSHEeaJcUyZamxw==",
+        "dependencies": {}
+      },
       "lilconfig@2.1.0": {
         "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
         "dependencies": {}
@@ -573,6 +693,10 @@
       },
       "lodash.uniq@4.5.0": {
         "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+        "dependencies": {}
+      },
+      "loglevel@1.8.1": {
+        "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
         "dependencies": {}
       },
       "lru-cache@10.1.0": {
@@ -602,11 +726,21 @@
         "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
         "dependencies": {}
       },
+      "minimatch@3.1.2": {
+        "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+        "dependencies": {
+          "brace-expansion": "brace-expansion@1.1.11"
+        }
+      },
       "minimatch@9.0.3": {
         "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
         "dependencies": {
           "brace-expansion": "brace-expansion@2.0.1"
         }
+      },
+      "minimist@1.2.8": {
+        "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+        "dependencies": {}
       },
       "minipass@7.0.4": {
         "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
@@ -658,6 +792,16 @@
       },
       "object-hash@3.0.0": {
         "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+        "dependencies": {}
+      },
+      "once@1.4.0": {
+        "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+        "dependencies": {
+          "wrappy": "wrappy@1.0.2"
+        }
+      },
+      "path-is-absolute@1.0.1": {
+        "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
         "dependencies": {}
       },
       "path-key@3.1.1": {
@@ -964,6 +1108,12 @@
           "picomatch": "picomatch@2.3.1"
         }
       },
+      "rechoir@0.6.2": {
+        "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+        "dependencies": {
+          "resolve": "resolve@1.22.8"
+        }
+      },
       "resolve@1.22.8": {
         "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
         "dependencies": {
@@ -991,6 +1141,18 @@
       "shebang-regex@3.0.0": {
         "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
         "dependencies": {}
+      },
+      "shelljs.exec@1.1.8": {
+        "integrity": "sha512-vFILCw+lzUtiwBAHV8/Ex8JsFjelFMdhONIsgKNLgTzeRckp2AOYRQtHJE/9LhNvdMmE27AGtzWx0+DHpwIwSw==",
+        "dependencies": {}
+      },
+      "shelljs@0.8.5": {
+        "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+        "dependencies": {
+          "glob": "glob@7.2.3",
+          "interpret": "interpret@1.4.0",
+          "rechoir": "rechoir@0.6.2"
+        }
       },
       "signal-exit@4.1.0": {
         "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
@@ -1057,6 +1219,12 @@
           "mz": "mz@2.7.0",
           "pirates": "pirates@4.0.6",
           "ts-interface-checker": "ts-interface-checker@0.1.13"
+        }
+      },
+      "supports-color@5.5.0": {
+        "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+        "dependencies": {
+          "has-flag": "has-flag@3.0.0"
         }
       },
       "supports-color@7.2.0": {
@@ -1167,6 +1335,10 @@
           "string-width": "string-width@5.1.2",
           "strip-ansi": "strip-ansi@7.1.0"
         }
+      },
+      "wrappy@1.0.2": {
+        "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+        "dependencies": {}
       },
       "yaml@2.3.4": {
         "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
@@ -2233,6 +2405,8 @@
     "https://esm.sh/stable/preact@10.19.2/denonext/hooks.js": "dfd710408bb1b988c7a33a33ce03b1d8076dd1d8140e0879ec78452a5f670726",
     "https://esm.sh/stable/preact@10.19.2/denonext/jsx-runtime.js": "f196c14042fc6019f3fed31eec7cfedea4669d0926858939380a5f54bd503798",
     "https://esm.sh/stable/preact@10.19.2/denonext/preact.mjs": "dc999b6432dc04d74ad7b692a8801f346294d815266dff915d0f222c120fd0b0",
+    "https://esm.sh/stable/preact@10.19.2/denonext/src.js": "dbb0b9b2a5b88f4d37b51a6b6f632ee9fd59bef1e71ca10dcaeaba90fe2759c0",
+    "https://esm.sh/v128/preact@10.19.2/src/index.js": "9f659159aebb93826877c7407a7461560e95ea7cc399c802a84d7175ecdda3aa",
     "https://esm.sh/v135/@babel/helper-validator-identifier@7.22.20/denonext/helper-validator-identifier.mjs": "1ad312a9040d1f3b096e90a3e6a9da7ecfc99662140852fe3862a316c2591c93",
     "https://esm.sh/v135/@preact/signals-core@1.5.0/X-ZS8q/denonext/signals-core.mjs": "69a658490da1b25f2f8d4476c45e7f1f45e08a04a0418119ab3d3b574d77b96a",
     "https://esm.sh/v135/@preact/signals@1.2.1/X-ZS8q/denonext/signals.mjs": "90531451d474fa35205f5f54e512ed566093722cb2a004316dc7b8d4b8122961",

--- a/external-clients/google.ts
+++ b/external-clients/google.ts
@@ -437,21 +437,16 @@ export async function refreshTokens(
 
 export async function getLocationAddress(
   { longitude, latitude }: Location,
-): Promise<string | null> {
+): Promise<string> {
   const cachedAddress = await getFacilityAddress(longitude, latitude)
-  if (cachedAddress) {
-    return cachedAddress
-  }
+  if (cachedAddress) return cachedAddress
 
   const data = await getGeocodeData(latitude, longitude)
   const address = getAddressFromData(data)
 
-  if (address) {
-    await cacheFacilityAddress(longitude, latitude, address)
-    return address
-  }
-
-  return null
+  assert(address)
+  await cacheFacilityAddress(longitude, latitude, address)
+  return address
 }
 
 async function getGeocodeData(

--- a/routes/app/facilities/[facility_id]/waiting-room/add.tsx
+++ b/routes/app/facilities/[facility_id]/waiting-room/add.tsx
@@ -57,12 +57,12 @@ export default async function WaitingRoomAdd(
   const patient_name = searchParams.get('patient_name')
   const just_completed_intake = url.searchParams.get('intake') === 'completed'
 
-  let completing_intake: Promise<ReturnedSqlRow<Patient>> | undefined
+  let completing_intake: Promise<unknown> = Promise.resolve()
   if (just_completed_intake) {
     assertOr400(patient_id, 'patient_id is required')
     completing_intake = patients.upsert(trx, {
       id: patient_id,
-      completed_onboarding: true,
+      completed_intake: true,
     })
   }
 
@@ -75,9 +75,10 @@ export default async function WaitingRoomAdd(
 
   let patient: { id?: number; name: string } | undefined
   if (patient_id) {
-    const fetched_patient = await (completing_intake || patients.getByID(trx, {
+    await completing_intake
+    const fetched_patient = await patients.getByID(trx, {
       id: patient_id,
-    }))
+    })
     assert(hasName(fetched_patient))
     patient = fetched_patient
   } else if (patient_name) {

--- a/routes/app/patients/[patient_id].tsx
+++ b/routes/app/patients/[patient_id].tsx
@@ -23,7 +23,7 @@ export default async function PatientPage(
 
   assertOr404(patient, 'Patient not found')
 
-  if (!patient.completed_onboarding) {
+  if (!patient.completed_intake) {
     return redirect(`${req.url}/intake`)
   }
 

--- a/routes/app/patients/[patient_id]/intake/[step].tsx
+++ b/routes/app/patients/[patient_id]/intake/[step].tsx
@@ -93,7 +93,7 @@ type OccupationFormValues = {
   school?: Maybe<Record<string, unknown>>
 }
 type LifestyleFormValues = Record<string, unknown>
-type ReviewFormValues = { completed_onboarding: boolean }
+type ReviewFormValues = { completed_intake: boolean }
 
 function assertIsPersonal(
   patient: unknown,
@@ -161,8 +161,8 @@ function assertIsReview(
 ): asserts patient is ReviewFormValues {
   assertOr400(isObjectLike(patient))
   assertOr400(
-    typeof patient.completed_onboarding === 'boolean' &&
-      patient.completed_onboarding,
+    typeof patient.completed_intake === 'boolean' &&
+      patient.completed_intake,
   )
 }
 
@@ -266,7 +266,7 @@ export const handler: LoggedInHealthWorkerHandler<IntakePatientProps> = {
       id: patient_id,
     })
 
-    const redirect_to = transformedFormData.completed_onboarding
+    const redirect_to = transformedFormData.completed_intake
       ? `/app/patients/${patient_id}/encounters/open/vitals`
       : `/app/patients/${patient_id}/intake/${getNextStep(step)}`
 

--- a/test/models/address.test.ts
+++ b/test/models/address.test.ts
@@ -5,6 +5,7 @@ import { resetInTest } from '../../db/reset.ts'
 import * as address from '../../db/models/address.ts'
 import { assert } from 'std/assert/assert.ts'
 import { createTestAddress } from '../mocks.ts'
+import omit from '../../util/omit.ts'
 
 describe('db/models/address.ts', { sanitizeResources: false }, () => {
   beforeEach(resetInTest)
@@ -16,7 +17,10 @@ describe('db/models/address.ts', { sanitizeResources: false }, () => {
       const address1 = await address.upsert(db, randomAddress)
       const address2 = await address.upsert(db, randomAddress)
 
-      assertEquals(address1, address2)
+      assertEquals(
+        omit(address1, ['updated_at']),
+        omit(address2, ['updated_at']),
+      )
       const { countAfterInitialInsert } = await db
         .selectFrom('address')
         .select(db.fn.countAll().as('countAfterInitialInsert'))

--- a/test/models/drugs.test.ts
+++ b/test/models/drugs.test.ts
@@ -11,6 +11,7 @@ describe('db/models/drugs.ts', { sanitizeResources: false }, () => {
   describe('search', () => {
     it('gets search results for drugs with their forms, strengths, and manufacturers', async () => {
       const results = await drugs.search(db, { search: 'abacavir' })
+      console.log(JSON.stringify(results, null, 2))
       assertEquals(
         deepOmit(results, [
           'drug_id',
@@ -385,6 +386,146 @@ const expected_results = [
             ],
             'trade_name': 'ABACAVIR SULPHATE; LAMIVUDINE',
             'manufacturer_name': 'HETERO LABS LTD, ANDHRA PRADESH INDIA;',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    'drug_id': 733,
+    'drug_generic_name': 'ABACAVIR; LAMIVUDINE',
+    'distinct_trade_names': [
+      'ABAMUNE L BABY',
+      'KIVEXA',
+    ],
+    'medications': [
+      {
+        'medication_id': 1004,
+        'form': 'CAPSULE',
+        'form_route': 'CAPSULE; ORAL',
+        'routes': [
+          'ORAL',
+        ],
+        'strength_numerators': [
+          30,
+          60,
+        ],
+        'strength_numerator_unit': 'MG',
+        'strength_denominator': 1,
+        'strength_denominator_unit': 'CAPSULE',
+        'strength_denominator_is_units': false,
+        'strength_summary': '30, 60MG',
+        'manufacturers': [
+          {
+            'manufactured_medication_id': 1857,
+            'strength_numerators': [
+              30,
+              60,
+            ],
+            'trade_name': 'ABAMUNE L BABY',
+            'manufacturer_name': 'CIPLA LTD MAHAD INDIA;',
+          },
+        ],
+      },
+      {
+        'medication_id': 1009,
+        'form': 'TABLET',
+        'form_route': 'TABLET; ORAL',
+        'routes': [
+          'ORAL',
+        ],
+        'strength_numerators': [
+          300,
+          600,
+        ],
+        'strength_numerator_unit': 'MG',
+        'strength_denominator': 1,
+        'strength_denominator_unit': 'TABLET',
+        'strength_denominator_is_units': false,
+        'strength_summary': '300, 600MG',
+        'manufacturers': [
+          {
+            'manufactured_medication_id': 1867,
+            'strength_numerators': [
+              300,
+              600,
+            ],
+            'trade_name': 'KIVEXA',
+            'manufacturer_name':
+              'GLAXOSMITHKLINE S.A (PTY) LTD BRYANSTON SOUTH AFRICA;',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    'drug_id': 734,
+    'drug_generic_name': 'ABACAVIR; DOLUTEGRAVIR; LAMIVUDINE',
+    'distinct_trade_names': [],
+    'medications': [
+      {
+        'medication_id': 1005,
+        'form': 'TABLET, COATED',
+        'form_route': 'TABLET, COATED; ORAL',
+        'routes': [
+          'ORAL',
+        ],
+        'strength_numerators': [
+          50,
+          300,
+          600,
+        ],
+        'strength_numerator_unit': 'MG',
+        'strength_denominator': 1,
+        'strength_denominator_unit': 'TABLET',
+        'strength_denominator_is_units': false,
+        'strength_summary': '50, 300, 600MG',
+        'manufacturers': [
+          {
+            'manufactured_medication_id': 1861,
+            'strength_numerators': [
+              50,
+              300,
+              600,
+            ],
+            'trade_name': 'ABACAVIR; DOLUTEGRAVIR; LAMIVUDINE',
+            'manufacturer_name': 'CIPLA LTD  INDIA;',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    'drug_id': 735,
+    'drug_generic_name': 'ABACAVIR SULPHATE; LAMIVUDINE; ZIDOVUDINE',
+    'distinct_trade_names': [],
+    'medications': [
+      {
+        'medication_id': 1008,
+        'form': 'TABLET',
+        'form_route': 'TABLET; ORAL',
+        'routes': [
+          'ORAL',
+        ],
+        'strength_numerators': [
+          150,
+          300,
+        ],
+        'strength_numerator_unit': 'MG',
+        'strength_denominator': 1,
+        'strength_denominator_unit': 'TABLET',
+        'strength_denominator_is_units': false,
+        'strength_summary': '150, 300MG',
+        'manufacturers': [
+          {
+            'manufactured_medication_id': 1866,
+            'strength_numerators': [
+              150,
+              300,
+              300,
+            ],
+            'trade_name': 'ABACAVIR SULPHATE; LAMIVUDINE; ZIDOVUDINE',
+            'manufacturer_name': 'MYLAN LABORATORIES LTD SINNAR INDIA;',
           },
         ],
       },

--- a/test/models/health_workers.test.ts
+++ b/test/models/health_workers.test.ts
@@ -376,9 +376,9 @@ describe('db/models/health_workers.ts', { sanitizeResources: false }, () => {
       assertEquals(result.gender, 'female')
       assertEquals(result.name, 'Worker')
       assertEquals(result.date_of_birth, '12 December 1999')
-      assertEquals(result.mobile_number, '5555555555') // <------ this is a problem (phone number formatting happens on display)
+      assertEquals(result.mobile_number, '5555555555')
       assertEquals(result.avatar_url, 'avatar_url')
-      assertEquals(result.date_of_first_practice, '1 January 2020') // <------ this is a problem (date gets moved back 16 hours)
+      assertEquals(result.date_of_first_practice, '1 January 2020')
       assertEquals(result.email, 'test@worker.com')
       assert(
         /^[0-9]{2}-[0-9]{6,7} [A-Z] [0-9]{2}$/.test(result.national_id_number!),

--- a/test/models/patients.test.ts
+++ b/test/models/patients.test.ts
@@ -40,7 +40,7 @@ describe('db/models/patients.ts', { sanitizeResources: false }, () => {
           dob_formatted: null,
           gender: null,
           ethnicity: null,
-          location: null,
+          location: { longitude: null, latitude: null },
           national_id_number: null,
           nearest_facility: null,
           phone_number: null,
@@ -48,7 +48,7 @@ describe('db/models/patients.ts', { sanitizeResources: false }, () => {
           updated_at: results[0].updated_at,
           last_visited: null,
           conversation_state: 'initial_message',
-          completed_onboarding: false,
+          completed_intake: false,
         },
         {
           id: testPatient2.id,
@@ -58,7 +58,7 @@ describe('db/models/patients.ts', { sanitizeResources: false }, () => {
           dob_formatted: null,
           gender: null,
           ethnicity: null,
-          location: null,
+          location: { longitude: null, latitude: null },
           national_id_number: null,
           nearest_facility: null,
           phone_number: null,
@@ -66,7 +66,7 @@ describe('db/models/patients.ts', { sanitizeResources: false }, () => {
           updated_at: results[1].updated_at,
           last_visited: null,
           conversation_state: 'initial_message',
-          completed_onboarding: false,
+          completed_intake: false,
         },
       ])
     })
@@ -90,7 +90,7 @@ describe('db/models/patients.ts', { sanitizeResources: false }, () => {
           dob_formatted: null,
           gender: null,
           ethnicity: null,
-          location: null,
+          location: { longitude: null, latitude: null },
           national_id_number: null,
           nearest_facility: null,
           phone_number: null,
@@ -105,7 +105,7 @@ describe('db/models/patients.ts', { sanitizeResources: false }, () => {
             history: {},
           },
           conversation_state: 'initial_message',
-          completed_onboarding: false,
+          completed_intake: false,
         },
       ])
     })

--- a/test/scheduling/makeAppointment.test.ts
+++ b/test/scheduling/makeAppointment.test.ts
@@ -78,7 +78,7 @@ describe('scheduling/makeAppointment.ts', { sanitizeResources: false }, () => {
           href: `/app/patients/${patient.id}`,
           id: patient.id,
           last_visited: null,
-          location: null,
+          location: { longitude: null, latitude: null },
           medical_record: {
             allergies: [
               'chocolate',
@@ -92,7 +92,7 @@ describe('scheduling/makeAppointment.ts', { sanitizeResources: false }, () => {
           phone_number: null,
           updated_at: patient.updated_at,
           conversation_state: 'initial_message',
-          completed_onboarding: false,
+          completed_intake: false,
         },
         patient_id: patient.id,
         reason: 'back pain',

--- a/types.ts
+++ b/types.ts
@@ -4,6 +4,7 @@ import { JSX } from 'preact/jsx-runtime'
 import { FreshContext, Handlers } from '$fresh/server.ts'
 import { Session, WithSession } from 'fresh_session'
 import db from './db/db.ts'
+import { DB } from './db.d.ts'
 
 export type Maybe<T> = T | null | undefined
 
@@ -40,18 +41,6 @@ export type Location = {
 
 export type Gender = 'male' | 'female' | 'other'
 
-export type Ethnicity =
-  | 'african'
-  | 'african_american'
-  | 'asian'
-  | 'caribbean'
-  | 'caucasian'
-  | 'hispanic'
-  | 'middle_eastern'
-  | 'native_american'
-  | 'pacific_islander'
-  | 'other'
-
 export type UserState<CS> = {
   body?: string
   has_media: boolean
@@ -81,7 +70,7 @@ export type PatientConversationState =
 export type Patient = PatientPersonal & {
   primary_doctor_id: Maybe<number>
   nearest_facility_id: Maybe<number>
-  completed_onboarding: boolean
+  completed_intake: boolean
   address_id: Maybe<number>
   unregistered_primary_doctor_name: Maybe<string>
 }
@@ -90,7 +79,7 @@ export type PatientDemographicInfo = {
   phone_number: Maybe<string>
   name: Maybe<string>
   gender: Maybe<Gender>
-  ethnicity: Maybe<Ethnicity>
+  ethnicity: Maybe<string>
   date_of_birth: Maybe<string>
   national_id_number: Maybe<string>
 }
@@ -105,12 +94,11 @@ export type RenderedPatient = ReturnedSqlRow<
     Patient,
     | 'gender'
     | 'ethnicity'
-    | 'location'
     | 'national_id_number'
     | 'phone_number'
     | 'name'
     | 'conversation_state'
-    | 'completed_onboarding'
+    | 'completed_intake'
   > & {
     dob_formatted: string | null
     // age_formatted: Maybe<string> // TODO: implement
@@ -118,6 +106,10 @@ export type RenderedPatient = ReturnedSqlRow<
     avatar_url: string | null
     nearest_facility: string | null
     last_visited: null // TODO: implement
+    location: {
+      longitude: number | null
+      latitude: number | null
+    }
   }
 >
 export type Condition = {
@@ -225,7 +217,7 @@ export type OnboardingPatient =
     | 'date_of_birth'
     | 'national_id_number'
     | 'nearest_facility_id'
-    | 'completed_onboarding'
+    | 'completed_intake'
     | 'primary_doctor_id'
     | 'unregistered_primary_doctor_name'
   >
@@ -310,7 +302,7 @@ export type PatientState = {
   }
   created_at: Date
   updated_at: Date
-  nearest_facilities?: ReturnedSqlRow<Facility>[]
+  nearest_facilities?: ReturnedSqlRow<PatientNearestFacility>[]
   nearest_facility_display_name?: string
   selectedFacility?: Facility
 }
@@ -468,7 +460,7 @@ export type AppointmentHealthWorkerAttendee = {
 
 export type PatientAppointmentRequest = {
   patient_id: number
-  reason?: string
+  reason: string | null
 }
 
 export type MatchingState<US extends UserState<any>> = {
@@ -1292,12 +1284,14 @@ export type Facility = Location & {
   name: string
   address: string
   category: string
-  distance: number
-  vha?: boolean
-  url?: string
-  phone?: string
-  walking_distance?: string | null
+  phone: string | null
   display_name: string
+}
+
+export type PatientNearestFacility = Facility & {
+  walking_distance: null | number
+  distance: number
+  vha: boolean
 }
 
 export type GoogleAddressComponent = {
@@ -1411,7 +1405,7 @@ export type Medication = {
   form_route: string
   strength_numerators: number[]
   strength_numerator_unit: string
-  strength_denominator: number
+  strength_denominator: string
   strength_denominator_unit: string
   strength_denominator_is_units: boolean
 }
@@ -1634,53 +1628,4 @@ export type Age = {
   units: AgeUnit
 }
 
-export type DatabaseSchema = {
-  appointments: SqlRow<Appointment>
-  patient_appointment_offered_times: SqlRow<PatientAppointmentOfferedTime>
-  patient_appointment_requests: SqlRow<PatientAppointmentRequest>
-  appointment_health_worker_attendees: SqlRow<AppointmentHealthWorkerAttendee>
-  health_workers: SqlRow<HealthWorker>
-  health_worker_google_tokens: SqlRow<HealthWorkerGoogleToken>
-  patients: SqlRow<Omit<Patient, 'conversation'>>
-  employment: SqlRow<Employee>
-  whatsapp_messages_received: SqlRow<WhatsAppMessageReceived>
-  whatsapp_messages_sent: SqlRow<WhatsAppMessageSent>
-  facilities: SqlRow<Facility>
-  patient_nearest_facilities: {
-    patient_id: number
-    nearest_facilities: ReturnedSqlRow<Facility>[]
-  }
-  health_worker_invitees: SqlRow<HealthWorkerInvitee>
-  media: SqlRow<PatientMedia>
-  nurse_registration_details: SqlRow<NurseRegistrationDetails>
-  nurse_specialties: SqlRow<Specialties>
-  appointment_media: SqlRow<AppointmentMedia>
-  patient_appointment_request_media: SqlRow<PatientAppointmentRequestMedia>
-  countries: SqlRow<Country>
-  provinces: SqlRow<Province>
-  districts: SqlRow<District>
-  wards: SqlRow<Ward>
-  suburbs: SqlRow<Suburb>
-  mailing_list: SqlRow<MailingListRecipient>
-  address: SqlRow<Address>
-  conditions: Condition
-  patient_conditions: SqlRow<PatientCondition>
-  drugs: SqlRow<Drug>
-  medications: SqlRow<Medication>
-  manufactured_medications: SqlRow<ManufacturedMedication>
-  patient_condition_medications: SqlRow<PatientMedication>
-  guardian_relations: GuardianRelation
-  patient_guardians: SqlRow<PatientGuardian>
-  allergies: SqlRow<Allergy>
-  patient_allergies: SqlRow<PatientAllergies>
-  patient_occupations: SqlRow<PatientOccupation>
-  patient_encounters: SqlRow<PatientEncounter>
-  patient_encounter_providers: SqlRow<PatientEncounterProvider>
-  waiting_room: SqlRow<WaitingRoom>
-  measurements: Measurement<keyof Measurements>
-  patient_measurements: SqlRow<PatientMeasurement>
-  patient_age: {
-    patient_id: number
-    age: Age
-  }
-}
+export type DatabaseSchema = DB

--- a/util/isNumber.ts
+++ b/util/isNumber.ts
@@ -1,0 +1,9 @@
+import getTag from './internal/getTag.ts'
+import isObjectLike from './isObjectLike.ts'
+
+export default function isNumber(value: unknown): value is number {
+  return (
+    typeof value === 'number' ||
+    (isObjectLike(value) && getTag(value) === '[object Number]')
+  )
+}


### PR DESCRIPTION
Uses kysely-codegen to generate types for us. Should remove much of the burden of having to define these types on our own and ensure that we're 1:1 with what's actually in the DB.

Run `deno task db:codegen` to generate the db.d.ts file in the project root, which is referenced by the types.ts file