### PR TITLE
Fixed add Examinations has wrong submit text

### DIFF
--- a/routes/app/patients/[patient_id]/encounters/[encounter_id]/examinations.tsx
+++ b/routes/app/patients/[patient_id]/encounters/[encounter_id]/examinations.tsx
@@ -325,7 +325,9 @@ export async function ExaminationsPage(
   })
 
   return {
-    next_step_text: adding_examinations ? 'Add Examinations' : `Continue to ${once_done}`,
+    next_step_text: adding_examinations
+      ? 'Add Examinations'
+      : `Continue to ${once_done}`,
     children: (
       <>
         <Tabs tabs={tabs} />


### PR DESCRIPTION
Added a condition when `ADD EXAMINATIONS` tab is active, the text displayed on the purple button reads `Add Examinations`
<img width="1470" alt="Screenshot 2024-09-19 at 6 08 53 PM" src="https://github.com/user-attachments/assets/d458cccc-4272-4065-be77-78730b228d44">
