### PR TITLE
Notification priority

### DIFF
--- a/components/library/layout/HealthWorkerHomePage.tsx
+++ b/components/library/layout/HealthWorkerHomePage.tsx
@@ -1,4 +1,5 @@
 import { ComponentChild, ComponentChildren } from 'preact'
+import type { Priority } from '../../../shared/priorities.ts'
 import type { RenderedEmployee } from '../../../types.ts'
 import HealthWorkerContentsWithSidebarAndDrawer from './HealthWorkerContentsWithSidebarAndDrawer.tsx'
 import { HealthWorkerSidebarBottom } from '../HealthWorkerSidebarBottom.tsx'
@@ -17,6 +18,7 @@ export function HealthWorkerHomePageLayout({
   drawer,
   tutorial,
   health_worker_notification_count = 0,
+  health_worker_notification_priority = null,
   children,
 }: {
   title: string
@@ -27,6 +29,7 @@ export function HealthWorkerHomePageLayout({
   drawer?: ComponentChild
   tutorial?: boolean
   health_worker_notification_count?: number
+  health_worker_notification_priority?: Priority | null
   children: ComponentChildren
 }) {
   return (
@@ -39,6 +42,7 @@ export function HealthWorkerHomePageLayout({
           params={params}
           urlSearchParams={url.searchParams}
           health_worker_notification_count={health_worker_notification_count}
+          health_worker_notification_priority={health_worker_notification_priority}
           bottom={<HealthWorkerSidebarBottom employee={employee} />}
           tutorial={tutorial}
         />

--- a/components/library/sidebar/Generic.tsx
+++ b/components/library/sidebar/Generic.tsx
@@ -28,6 +28,7 @@ export function GenericSidebar(
                     ' & ',
                   )}
                 count={link.count}
+                notification_priority={link.notification_priority}
                 Icon={link.Icon}
               />
             ))}

--- a/components/library/sidebar/HealthWorkerHomePage.tsx
+++ b/components/library/sidebar/HealthWorkerHomePage.tsx
@@ -1,4 +1,5 @@
 import { ComponentChild } from 'preact'
+import type { Priority } from '../../../shared/priorities.ts'
 import { practitionerHomePageNavLinks } from './home_page_links/health_worker.ts'
 import { HealthWorkerDefaultTop } from './Top.tsx'
 import { GenericSidebar } from './Generic.tsx'
@@ -8,19 +9,31 @@ export type HealthWorkerHomePageSidebarProps = {
   params: Record<string, string>
   urlSearchParams: URLSearchParams
   health_worker_notification_count: number
+  health_worker_notification_priority: Priority | null
   bottom?: ComponentChild
   tutorial?: boolean
 }
 
 export function HealthWorkerHomePageSidebar(
-  { route, params, urlSearchParams, health_worker_notification_count, bottom, tutorial }: HealthWorkerHomePageSidebarProps,
+  {
+    route,
+    params,
+    urlSearchParams,
+    health_worker_notification_count,
+    health_worker_notification_priority,
+    bottom,
+    tutorial,
+  }: HealthWorkerHomePageSidebarProps,
 ) {
   return (
     <GenericSidebar
       route={route}
       params={params}
       urlSearchParams={urlSearchParams}
-      nav_links={practitionerHomePageNavLinks({ health_worker_notification_count })}
+      nav_links={practitionerHomePageNavLinks({
+        health_worker_notification_count,
+        health_worker_notification_priority,
+      })}
       top={<HealthWorkerDefaultTop />}
       bottom={bottom}
       tutorial={tutorial}

--- a/components/library/sidebar/NavItem.tsx
+++ b/components/library/sidebar/NavItem.tsx
@@ -10,6 +10,7 @@ export function NavItem({
   title,
   active,
   count,
+  notification_priority,
   Icon,
 }: LinkProps) {
   if (typeof count === 'number') {
@@ -26,7 +27,9 @@ export function NavItem({
       >
         {Icon && <Icon className='w-5' active={active} />}
         <SidebarNavItemText>{title}</SidebarNavItemText>
-        {typeof count === 'number' && <NotificationBubble count={count} />}
+        {typeof count === 'number' && (
+          <NotificationBubble count={count} priority={notification_priority ?? null} />
+        )}
       </a>
     </li>
   )

--- a/components/library/sidebar/NavItem.tsx
+++ b/components/library/sidebar/NavItem.tsx
@@ -27,9 +27,7 @@ export function NavItem({
       >
         {Icon && <Icon className='w-5' active={active} />}
         <SidebarNavItemText>{title}</SidebarNavItemText>
-        {typeof count === 'number' && (
-          <NotificationBubble count={count} priority={notification_priority ?? null} />
-        )}
+        {typeof count === 'number' && <NotificationBubble count={count} priority={notification_priority ?? null} />}
       </a>
     </li>
   )

--- a/components/library/sidebar/home_page_links/health_worker.ts
+++ b/components/library/sidebar/home_page_links/health_worker.ts
@@ -11,11 +11,16 @@ import {
   PresentationChartBarIcon,
   Squares2x2Icon,
 } from '../../icons/heroicons/outline.tsx'
+import type { Priority } from '../../../../shared/priorities.ts'
 import { LinkDef } from '../../../../types.ts'
 
-export function practitionerHomePageNavLinks(
-  { health_worker_notification_count }: { health_worker_notification_count: number },
-): LinkDef[] {
+export function practitionerHomePageNavLinks({
+  health_worker_notification_count,
+  health_worker_notification_priority,
+}: {
+  health_worker_notification_count: number
+  health_worker_notification_priority: Priority | null
+}): LinkDef[] {
   return [
     {
       route: '/app/organizations/:organization_id/dashboard',
@@ -59,6 +64,7 @@ export function practitionerHomePageNavLinks(
       title: 'Notifications',
       Icon: BellIcon,
       count: health_worker_notification_count,
+      notification_priority: health_worker_notification_priority,
     },
     { route: '/app/logout', title: 'Log Out', Icon: ArrowRightOnRectangleIcon },
   ]

--- a/db.d.ts
+++ b/db.d.ts
@@ -559,6 +559,7 @@ export interface HealthWorkerWebNotifications {
   health_worker_id: string
   id: Generated<string>
   notification_type: string
+  patient_encounter_id: string | null
   row_id: string
   seen_at: Timestamp | null
   table_name: string

--- a/db/migrations/20250110030806_notifications.ts
+++ b/db/migrations/20250110030806_notifications.ts
@@ -17,12 +17,18 @@ export function up(db: Kysely<DB>) {
         .addColumn('avatar_url', 'text', (col) => col.notNull())
         .addColumn('action_title', 'text', (col) => col.notNull())
         .addColumn('action_href', 'text', (col) => col.notNull())
-        .addColumn('seen_at', 'timestamptz'),
+        .addColumn('seen_at', 'timestamptz')
+        .addColumn('patient_encounter_id', 'uuid', (col) => col.references('patient_encounters.id')),
   ).then(async () => {
     await db.schema
       .createIndex('idx_health_worker_web_notifications_health_worker_id')
       .on('health_worker_web_notifications')
       .column('health_worker_id')
+      .execute()
+    await db.schema
+      .createIndex('idx_health_worker_web_notifications_unread_priority_lookup')
+      .on('health_worker_web_notifications')
+      .columns(['health_worker_id', 'seen_at', 'patient_encounter_id'])
       .execute()
   })
 }

--- a/db/models/notifications.ts
+++ b/db/models/notifications.ts
@@ -1,17 +1,6 @@
 import { sql } from 'kysely'
-import {
-  isPriority,
-  ORDERED_PRIORITIES,
-  PRIORITY_SNOMED_CODES,
-  Priority,
-} from '../../shared/priorities.ts'
-import {
-  NonEmptyArray,
-  PostgresInterval,
-  RenderedNotification,
-  TrxOrDb,
-  TrxOrDbOrQueryCreator,
-} from '../../types.ts'
+import { isPriority, ORDERED_PRIORITIES, Priority, PRIORITY_SNOMED_CODES } from '../../shared/priorities.ts'
+import { NonEmptyArray, PostgresInterval, RenderedNotification, TrxOrDb, TrxOrDbOrQueryCreator } from '../../types.ts'
 import { orderByArrayPosition } from '../helpers.ts'
 import { timeAgoDisplay } from '../../util/timeAgoDisplay.ts'
 import { base } from './_base.ts'
@@ -174,11 +163,9 @@ export const notifications = base({
                   eb_triage_level,
                   'patient_records.value_snomed_concept_id',
                   ENCOUNTER_PRIORITY_SNOMED_ORDER,
-                ),
-                'desc',
-              )
+                ), 'desc')
               .limit(1)
-              .as('encounter_priority'),
+              .as('encounter_priority')
           )
           .as('unread_encounter_notification_priorities')
       )
@@ -189,9 +176,7 @@ export const notifications = base({
           eb,
           'encounter_priority',
           ENCOUNTER_ORDERED_PRIORITIES,
-        ),
-        'desc',
-      )
+        ), 'desc')
       .limit(1)
       .executeTakeFirst()
 

--- a/db/models/notifications.ts
+++ b/db/models/notifications.ts
@@ -63,7 +63,7 @@ export const notifications = base({
   },
   insert(
     trx: TrxOrDbOrQueryCreator,
-    { health_worker_id, employment_id, ...notification }:
+    { health_worker_id, employment_id, patient_encounter_id, ...notification }:
       & {
         action_title: string
         action_href: string
@@ -73,6 +73,7 @@ export const notifications = base({
         row_id: string
         notification_type: string
         title: string
+        patient_encounter_id?: string | null
       }
       & (
         | { health_worker_id: string; employment_id?: never }
@@ -83,6 +84,7 @@ export const notifications = base({
       .insertInto('health_worker_web_notifications')
       .values({
         ...notification,
+        patient_encounter_id: patient_encounter_id ?? null,
         health_worker_id: health_worker_id ||
           trx.selectFrom('employment').select('health_worker_id').where(
             'id',

--- a/db/models/notifications.ts
+++ b/db/models/notifications.ts
@@ -1,8 +1,30 @@
 import { sql } from 'kysely'
-import { PostgresInterval, RenderedNotification, TrxOrDbOrQueryCreator } from '../../types.ts'
+import {
+  isPriority,
+  ORDERED_PRIORITIES,
+  PRIORITY_SNOMED_CODES,
+  Priority,
+} from '../../shared/priorities.ts'
+import {
+  NonEmptyArray,
+  PostgresInterval,
+  RenderedNotification,
+  TrxOrDb,
+  TrxOrDbOrQueryCreator,
+} from '../../types.ts'
+import { orderByArrayPosition } from '../helpers.ts'
 import { timeAgoDisplay } from '../../util/timeAgoDisplay.ts'
 import { base } from './_base.ts'
 import { assertOr400 } from '../../util/assertOr.ts'
+
+// Deceased is in ORDERED_PRIORITIES but is not assigned as a live encounter triage level.
+const ENCOUNTER_ORDERED_PRIORITIES = ORDERED_PRIORITIES.filter(
+  (priority) => priority !== 'Deceased',
+) as NonEmptyArray<Priority>
+
+const ENCOUNTER_PRIORITY_SNOMED_ORDER = ENCOUNTER_ORDERED_PRIORITIES.map(
+  (priority) => PRIORITY_SNOMED_CODES[priority],
+) as NonEmptyArray<string>
 
 type Terms = {
   health_worker_id: string
@@ -94,5 +116,86 @@ export const notifications = base({
       })
       .returning('id')
       .executeTakeFirstOrThrow()
+  },
+  async highestUnreadPriority(
+    trx: TrxOrDb,
+    { health_worker_id }: { health_worker_id: string },
+  ): Promise<Priority | null> {
+    assertOr400(health_worker_id)
+    const row = await trx
+      .selectFrom((eb) =>
+        eb
+          .selectFrom('health_worker_web_notifications')
+          .where('health_worker_id', '=', health_worker_id)
+          .where('seen_at', 'is', null)
+          .where('patient_encounter_id', 'is not', null)
+          .select((eb_notification) =>
+            eb_notification
+              .selectFrom('patient_triage_level')
+              .innerJoin(
+                'patient_records',
+                'patient_triage_level.id',
+                'patient_records.id',
+              )
+              .innerJoin(
+                'patient_records_still_valid',
+                'patient_records.id',
+                'patient_records_still_valid.id',
+              )
+              .innerJoin(
+                'snomed_inferred_canonical_name_and_category',
+                'patient_records.value_snomed_concept_id',
+                'snomed_inferred_canonical_name_and_category.id',
+              )
+              .whereRef(
+                'patient_records.patient_encounter_id',
+                '=',
+                'health_worker_web_notifications.patient_encounter_id',
+              )
+              .where((eb_x) =>
+                eb_x.exists(
+                  trx
+                    .selectFrom('patient_records_still_valid as associated_findings_still_valid')
+                    .innerJoin(
+                      'patient_record_relations as triage_relations',
+                      'triage_relations.destination_id',
+                      'associated_findings_still_valid.id',
+                    )
+                    .where(
+                      'triage_relations.source_id',
+                      '=',
+                      eb_x.ref('patient_triage_level.id'),
+                    ),
+                )
+              )
+              .select('snomed_inferred_canonical_name_and_category.name')
+              .orderBy((eb_triage_level) =>
+                orderByArrayPosition(
+                  eb_triage_level,
+                  'patient_records.value_snomed_concept_id',
+                  ENCOUNTER_PRIORITY_SNOMED_ORDER,
+                ),
+                'desc',
+              )
+              .limit(1)
+              .as('encounter_priority'),
+          )
+          .as('unread_encounter_notification_priorities')
+      )
+      .where('encounter_priority', 'is not', null)
+      .select('encounter_priority')
+      .orderBy((eb) =>
+        orderByArrayPosition(
+          eb,
+          'encounter_priority',
+          ENCOUNTER_ORDERED_PRIORITIES,
+        ),
+        'desc',
+      )
+      .limit(1)
+      .executeTakeFirst()
+
+    const priority = row?.encounter_priority
+    return priority && isPriority(priority) ? priority : null
   },
 })

--- a/events/handlers.ts
+++ b/events/handlers.ts
@@ -360,6 +360,7 @@ export const EVENTS = {
             avatar_url: '/images/heroicons/24/solid/exclamation-triangle.svg',
             description: `${employeeDisplay(requested_by_employee).display_name} has requested immediate triage for a patient`,
             employment_id: employee.employee_id,
+            patient_encounter_id,
             table_name: 'patient_encounters',
             row_id: patient_encounter_id,
             notification_type: 'patient_encounter_immediate_triage',

--- a/islands/NotificationBubble.tsx
+++ b/islands/NotificationBubble.tsx
@@ -1,9 +1,11 @@
 import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
-import type { Priority } from '../shared/priorities.ts'
+import { priorityColors, type Priority } from '../shared/priorities.ts'
+import cls from '../util/cls.ts'
 
 export function NotificationBubble(props: { count: number; priority: Priority | null }) {
   const count = useSignal(props.count)
+  const colors = priorityColors(props.priority)
 
   useEffect(() => {
     function listener() {
@@ -18,7 +20,13 @@ export function NotificationBubble(props: { count: number; priority: Priority | 
   if (!count.value) return null
 
   return (
-    <span className='count ml-auto inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full bg-red-500 text-white text-xs font-medium'>
+    <span
+      className={cls(
+        'count ml-auto inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full text-xs font-medium',
+        colors.bg,
+        colors.text,
+      )}
+    >
       {count.value > 99 ? '99+' : count.value}
     </span>
   )

--- a/islands/NotificationBubble.tsx
+++ b/islands/NotificationBubble.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
-import { priorityColors, type Priority } from '../shared/priorities.ts'
+import { type Priority, priorityColors } from '../shared/priorities.ts'
 import cls from '../util/cls.ts'
 
 export function NotificationBubble(props: { count: number; priority: Priority | null }) {

--- a/islands/NotificationBubble.tsx
+++ b/islands/NotificationBubble.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
+import type { Priority } from '../shared/priorities.ts'
 
-export function NotificationBubble(props: { count: number }) {
+export function NotificationBubble(props: { count: number; priority: Priority | null }) {
   const count = useSignal(props.count)
 
   useEffect(() => {

--- a/routes/app/_middleware.tsx
+++ b/routes/app/_middleware.tsx
@@ -180,23 +180,22 @@ export function HealthWorkerHomePage<
       title = undefined as any
     }
 
-    let { rendered, health_worker_notification_count, health_worker_notification_priority } =
-      await promiseProps({
-        rendered: Promise.resolve(
-          render!(ctx),
-        ),
-        health_worker_notification_count: notifications.countAll(
-          trx,
-          {
-            health_worker_id: health_worker.id,
-            only_unread: true,
-          },
-        ),
-        health_worker_notification_priority: notifications.highestUnreadPriority(
-          trx,
-          { health_worker_id: health_worker.id },
-        ),
-      })
+    let { rendered, health_worker_notification_count, health_worker_notification_priority } = await promiseProps({
+      rendered: Promise.resolve(
+        render!(ctx),
+      ),
+      health_worker_notification_count: notifications.countAll(
+        trx,
+        {
+          health_worker_id: health_worker.id,
+          only_unread: true,
+        },
+      ),
+      health_worker_notification_priority: notifications.highestUnreadPriority(
+        trx,
+        { health_worker_id: health_worker.id },
+      ),
+    })
 
     let drawer: JSX.Element | undefined
     if (rendered instanceof Response) {

--- a/routes/app/_middleware.tsx
+++ b/routes/app/_middleware.tsx
@@ -180,18 +180,23 @@ export function HealthWorkerHomePage<
       title = undefined as any
     }
 
-    let { rendered, health_worker_notification_count } = await promiseProps({
-      rendered: Promise.resolve(
-        render!(ctx),
-      ),
-      health_worker_notification_count: notifications.countAll(
-        trx,
-        {
-          health_worker_id: health_worker.id,
-          only_unread: true,
-        },
-      ),
-    })
+    let { rendered, health_worker_notification_count, health_worker_notification_priority } =
+      await promiseProps({
+        rendered: Promise.resolve(
+          render!(ctx),
+        ),
+        health_worker_notification_count: notifications.countAll(
+          trx,
+          {
+            health_worker_id: health_worker.id,
+            only_unread: true,
+          },
+        ),
+        health_worker_notification_priority: notifications.highestUnreadPriority(
+          trx,
+          { health_worker_id: health_worker.id },
+        ),
+      })
 
     let drawer: JSX.Element | undefined
     if (rendered instanceof Response) {
@@ -221,6 +226,7 @@ export function HealthWorkerHomePage<
           organization_id: defaultOrganizationId(ctx.state.health_worker),
         }}
         health_worker_notification_count={health_worker_notification_count}
+        health_worker_notification_priority={health_worker_notification_priority}
         drawer={drawer}
       >
         {rendered}

--- a/routes/app/organizations/[organization_id]/patients/[patient_id]/open_encounter/triage/route_patient.tsx
+++ b/routes/app/organizations/[organization_id]/patients/[patient_id]/open_encounter/triage/route_patient.tsx
@@ -85,6 +85,7 @@ export const handler = postHandler(
               action_href: '#todo',
               avatar_url: ctx.state.health_worker.avatar_url!,
               description: `A case was referred to you`,
+              patient_encounter_id: ctx.state.patient_encounter_id,
               table_name: 'patient_encounters',
               row_id: ctx.state.patient_encounter_id,
               notification_type: 'case_referral',

--- a/types.ts
+++ b/types.ts
@@ -1597,6 +1597,7 @@ export type LinkProps = {
   title: string
   active: boolean
   count?: number
+  notification_priority?: Priority | null
   Icon?: (
     props: Omit<JSX.SVGAttributes<SVGSVGElement>, 'className'> & {
       active: boolean
@@ -1609,6 +1610,7 @@ export type LinkDef = {
   route: string
   title: string
   count?: number
+  notification_priority?: Priority | null
   Icon?: (
     props: Omit<JSX.SVGAttributes<SVGSVGElement>, 'className'> & {
       active: boolean


### PR DESCRIPTION
Summary:
- Added patient_encounter_id to health_worker_web_notifications so encounter-related notifications can link directly to patient encounters.
- Updated notification insert logic and encounter-related notification call sites to persist patient_encounter_id.
- Added notifications.highestUnreadPriority to derive the highest unread notification priority from current encounter triage data.
- Wired the derived priority through middleware, layout, sidebar, and NotificationBubble props.
- Updated NotificationBubble to use shared priorityColors instead of hardcoded red styling.

Testing:
- Rebuilt DB and verified db.d.ts includes patient_encounter_id: string | null.
- Ran deno check on changed model, middleware, route, and UI files.
- Manually verified the notification bubble uses the shared priority color styling on page load.

Note:
- WebSocket live updates still increment the notification count only. Live priority color refresh is intentionally left out of scope for this PR.