### PR TITLE
Refactor notifications websocket to use pg notify

### DIFF
--- a/db/migrations/20260605120000_notify_health_worker_notification_inserted.ts
+++ b/db/migrations/20260605120000_notify_health_worker_notification_inserted.ts
@@ -1,0 +1,29 @@
+import { Kysely, sql } from 'kysely'
+import type { DB } from '../../db.d.ts'
+
+export async function up(db: Kysely<DB>) {
+  await sql`
+    CREATE OR REPLACE FUNCTION notify_health_worker_notification_inserted()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      PERFORM pg_notify('health_worker_notification_inserted', json_build_object(
+        'id', NEW.id,
+        'health_worker_id', NEW.health_worker_id
+      )::text);
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  `.execute(db)
+
+  await sql`
+    CREATE TRIGGER health_worker_notification_inserted_trigger
+    AFTER INSERT ON health_worker_web_notifications
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_health_worker_notification_inserted();
+  `.execute(db)
+}
+
+export async function down(db: Kysely<DB>) {
+  await sql`DROP TRIGGER IF EXISTS health_worker_notification_inserted_trigger ON health_worker_web_notifications`.execute(db)
+  await sql`DROP FUNCTION IF EXISTS notify_health_worker_notification_inserted`.execute(db)
+}

--- a/db/models/notifications.ts
+++ b/db/models/notifications.ts
@@ -1,10 +1,106 @@
 import { sql } from 'kysely'
+import { Client } from 'pg'
 import { isPriority, ORDERED_PRIORITIES, Priority, PRIORITY_SNOMED_CODES } from '../../shared/priorities.ts'
 import { NonEmptyArray, PostgresInterval, RenderedNotification, TrxOrDb, TrxOrDbOrQueryCreator } from '../../types.ts'
 import { orderByArrayPosition } from '../helpers.ts'
 import { timeAgoDisplay } from '../../util/timeAgoDisplay.ts'
 import { base } from './_base.ts'
 import { assertOr400 } from '../../util/assertOr.ts'
+import { opts } from '../db.ts'
+import { assert } from 'std/assert/assert.ts'
+import { isUUID } from '../../util/uuid.ts'
+import { exists } from '../../util/exists.ts'
+import assertHasProperty from '../../util/assertHasProperty.ts'
+
+const _PUBSUB_GLOBAL_KEY = '__vha_notificationsPubSub__'
+
+type NotificationsPubSub = {
+  by_health_worker_id: {
+    subscribe(health_worker_id: string, callback: (notification_id: string) => void): void
+    unsubscribe(health_worker_id: string, callback: (notification_id: string) => void): void
+  }
+  shutdown(): Promise<void>
+}
+
+let notifications_pub_sub_promise: Promise<NotificationsPubSub> | undefined
+
+async function createNotificationsPubSub(): Promise<NotificationsPubSub> {
+  const by_health_worker_id_subscribers = new Map<string, Set<(notification_id: string) => void>>()
+
+  const client = new Client(opts || {})
+  await client.connect()
+  await client.query(`LISTEN health_worker_notification_inserted`)
+
+  const on_notification = (event: { channel?: string; payload?: string }) => {
+    if (event.channel !== 'health_worker_notification_inserted') return
+    assert(event.payload)
+    const notification = JSON.parse(event.payload)
+    assertHasProperty(notification, 'id')
+    assertHasProperty(notification, 'health_worker_id')
+    assert(isUUID(notification.id))
+    assert(isUUID(notification.health_worker_id))
+    const subscriptions = by_health_worker_id_subscribers.get(notification.health_worker_id)
+    if (!subscriptions?.size) return
+    for (const subscription of subscriptions) {
+      subscription(notification.id)
+    }
+  }
+  client.on('notification', on_notification)
+
+  return {
+    by_health_worker_id: {
+      subscribe(health_worker_id: string, callback: (notification_id: string) => void) {
+        assert(isUUID(health_worker_id))
+        if (!by_health_worker_id_subscribers.has(health_worker_id)) {
+          by_health_worker_id_subscribers.set(health_worker_id, new Set())
+        }
+        const subscriptions = exists(by_health_worker_id_subscribers.get(health_worker_id))
+        subscriptions.add(callback)
+      },
+      unsubscribe(health_worker_id: string, callback: (notification_id: string) => void) {
+        assert(isUUID(health_worker_id))
+        const subscriptions = by_health_worker_id_subscribers.get(health_worker_id)
+        subscriptions?.delete(callback)
+        if (!subscriptions?.size) {
+          by_health_worker_id_subscribers.delete(health_worker_id)
+        }
+      },
+    },
+    async shutdown() {
+      by_health_worker_id_subscribers.clear()
+      client.removeListener('notification', on_notification)
+      client.removeAllListeners('notification')
+      try {
+        await client.query('UNLISTEN health_worker_notification_inserted')
+      } catch {
+        // Connection may already be closing.
+      }
+      await client.end()
+    },
+  }
+}
+
+async function initializeNotificationsPubSubImpl(): Promise<NotificationsPubSub> {
+  // deno-lint-ignore no-explicit-any
+  const existing = (globalThis as any)[_PUBSUB_GLOBAL_KEY] as NotificationsPubSub | undefined
+  if (existing) return existing
+
+  notifications_pub_sub_promise ||= createNotificationsPubSub().then((instance) => {
+    // deno-lint-ignore no-explicit-any
+    ;(globalThis as any)[_PUBSUB_GLOBAL_KEY] = instance
+    return instance
+  })
+  return await notifications_pub_sub_promise
+}
+
+const initialize_notifications_pub_sub = Object.assign(
+  initializeNotificationsPubSubImpl,
+  {
+    get called() {
+      return !!notifications_pub_sub_promise
+    },
+  },
+)
 
 // Deceased is in ORDERED_PRIORITIES but is not assigned as a live encounter triage level.
 const ENCOUNTER_ORDERED_PRIORITIES = ORDERED_PRIORITIES.filter(
@@ -22,7 +118,7 @@ type Terms = {
   recent_first?: boolean
 }
 
-export const notifications = base({
+const notifications_base = base({
   top_level_table: 'health_worker_web_notifications',
   baseQuery(trx, terms: Terms) {
     assertOr400(terms.health_worker_id)
@@ -182,5 +278,18 @@ export const notifications = base({
 
     const priority = row?.encounter_priority
     return priority && isPriority(priority) ? priority : null
+  },
+})
+
+export const notifications = Object.assign(notifications_base, {
+  initializeNotificationsPubSub: initialize_notifications_pub_sub,
+  async closeNotificationsPubSub(opts: { graceful: boolean }) {
+    assert(!opts.graceful, 'TODO support a graceful mode')
+    if (!notifications_pub_sub_promise) return
+    const pub_sub = await notifications_pub_sub_promise
+    await pub_sub.shutdown()
+    // deno-lint-ignore no-explicit-any
+    delete (globalThis as any)[_PUBSUB_GLOBAL_KEY]
+    notifications_pub_sub_promise = undefined
   },
 })

--- a/routes/app/notifications-websocket.ts
+++ b/routes/app/notifications-websocket.ts
@@ -1,5 +1,5 @@
 import { notifications } from '../../db/models/notifications.ts'
-import { LoggedInHealthWorkerContext } from '../../types.ts'
+import { LoggedInHealthWorkerContext, RenderedNotification } from '../../types.ts'
 import upgradeWebsocket from '../../util/websocket.ts'
 import last from '../../util/last.ts'
 
@@ -7,48 +7,56 @@ export default upgradeWebsocket((
   ctx: LoggedInHealthWorkerContext,
   socket: WebSocket,
 ) => {
-  console.log('upgraded websocket')
-  // deno-lint-ignore no-explicit-any
-  let timeout: any
   let past_ts: Date | undefined
+  const health_worker_id = ctx.state.health_worker.id
+  let pub_sub: Awaited<ReturnType<typeof notifications.initializeNotificationsPubSub>> | undefined
 
-  async function loop() {
-    console.log('notifications-websocket loop')
-    notifications.verbose = true
-    const new_notifications = await notifications.findAll(
-      ctx.state.trx,
-      {
-        health_worker_id: ctx.state.health_worker.id,
-        past_ts,
-      },
-    )
-    for (const new_notification of new_notifications) {
-      console.log('new_notification weklewkl', new_notification)
-      if (!past_ts || (new_notification.created_at > past_ts)) {
-        socket.send(JSON.stringify({
-          ...new_notification,
-          type: 'new_notification',
-        }))
-      }
-      past_ts = new_notification.created_at
+  const sendIfNew = (new_notification: RenderedNotification) => {
+    if (!past_ts || (new_notification.created_at > past_ts)) {
+      socket.send(JSON.stringify({
+        ...new_notification,
+        type: 'new_notification',
+      }))
     }
-    timeout = setTimeout(loop, 1000)
+    past_ts = new_notification.created_at
+  }
+
+  const on_notification = async (notification_id: string) => {
+    try {
+      const new_notification = await notifications.getByIdOptional(
+        ctx.state.trx,
+        notification_id,
+        { health_worker_id },
+      )
+      if (!new_notification) return
+      sendIfNew(new_notification)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  const cleanup = () => {
+    pub_sub?.by_health_worker_id.unsubscribe(health_worker_id, on_notification)
   }
 
   socket.onopen = async () => {
+    pub_sub = await notifications.initializeNotificationsPubSub()
+    pub_sub.by_health_worker_id.subscribe(health_worker_id, on_notification)
+
     const notifs = await notifications.findAll(
       ctx.state.trx,
-      {
-        health_worker_id: ctx.state.health_worker.id,
-      },
+      { health_worker_id },
     )
     past_ts = last(notifs)?.created_at
-    await loop()
+
+    const new_notifications = await notifications.findAll(
+      ctx.state.trx,
+      { health_worker_id, past_ts },
+    )
+    for (const new_notification of new_notifications) {
+      sendIfNew(new_notification)
+    }
   }
-  socket.onclose = () => clearTimeout(timeout)
-  socket.onerror = (/* error */) => {
-    // TODO: distinguish between different socket errors?
-    // console.error('SOCKET ERROR:', error)
-    clearTimeout(timeout)
-  }
+  socket.onclose = cleanup
+  socket.onerror = cleanup
 })

--- a/test/models/notifications.test.ts
+++ b/test/models/notifications.test.ts
@@ -1,0 +1,52 @@
+import { afterAll, before, describe, it } from 'std/testing/bdd.ts'
+import { assertEquals } from 'std/assert/assert_equals.ts'
+import db from '../../db/db.ts'
+import { notifications } from '../../db/models/notifications.ts'
+import { addTestEmployee } from '../_helpers/employees.ts'
+import { timeout } from '../../util/timeout.ts'
+
+describe('db/models/notifications.ts', () => {
+  before(async () => {
+    await notifications.initializeNotificationsPubSub()
+  })
+  afterAll(async () => {
+    await notifications.closeNotificationsPubSub({ graceful: false })
+    await db.destroy()
+  })
+
+  describe('initializeNotificationsPubSub', () => {
+    it(
+      'notifies subscribers when a notification is inserted',
+      async () => {
+        const health_worker = await addTestEmployee(db, { role: 'nurse' })
+        const pub_sub = await notifications.initializeNotificationsPubSub()
+        const received = Promise.withResolvers<string>()
+        const callback = (notification_id: string) => received.resolve(notification_id)
+        pub_sub.by_health_worker_id.subscribe(health_worker.id, callback)
+
+        try {
+          const { id } = await notifications.insert(db, {
+            health_worker_id: health_worker.id,
+            title: 'Test notification',
+            description: 'Test description',
+            avatar_url: '/images/test.svg',
+            table_name: 'patient_encounters',
+            row_id: '00000000-0000-1000-8000-000000000099',
+            notification_type: 'test',
+            action_title: 'View',
+            action_href: '/app',
+          })
+
+          const timer = timeout(5000)
+          try {
+            assertEquals(await Promise.race([received.promise, timer]), id)
+          } finally {
+            timer.cancel()
+          }
+        } finally {
+          pub_sub.by_health_worker_id.unsubscribe(health_worker.id, callback)
+        }
+      },
+    )
+  })
+})


### PR DESCRIPTION
Refactored health worker notification delivery from per-client polling to Postgres pg_notify/LISTEN.

Changes:
- Added an AFTER INSERT trigger on health_worker_web_notifications that emits pg_notify with notification id and health_worker_id.
- Added a dedicated notifications pub/sub listener using pg.Client, modeled after the existing events pub/sub pattern.
- Updated notifications WebSocket to subscribe to health-worker-specific notification events instead of polling every second.
- Preserved existing WebSocket message shape and catch-up behavior.
- Added a model-level integration test for the pg_notify/LISTEN path.

Validation:
- deno fmt
- deno task check
- deno task test test/models/notifications.test.ts
- /opt/homebrew/bin/bash ./scripts/test/test.sh test/web/patients/open_encounter/triage/route_patient.test.ts

Also attempted full test/web locally; most tests passed, but 3 failed due to transient local Postgres "too many clients already" during parallel setup. pg_stat_activity returned to 6 connections afterward, so this does not appear to be a persistent connection leak from the new LISTEN client.