### PR TITLE
Push notification

### DIFF
--- a/components/calendar/ScheduleForm.tsx
+++ b/components/calendar/ScheduleForm.tsx
@@ -25,7 +25,7 @@ export default function ScheduleForm(
       </FormRow>
       <FormRow>
         <PersonSearch
-          name='provider'
+          name='employee'
           search_route='/app/providers?roles=[doctor,nurse]'
         />
       </FormRow>

--- a/db.d.ts
+++ b/db.d.ts
@@ -567,6 +567,17 @@ export interface HealthWorkerWebNotifications {
   updated_at: Generated<Timestamp>
 }
 
+export interface HealthWorkerWebPushSubscriptions {
+  auth: string
+  created_at: Generated<Timestamp>
+  endpoint: string
+  health_worker_id: string
+  id: Generated<string>
+  p256dh: string
+  updated_at: Generated<Timestamp>
+  user_agent: string | null
+}
+
 export interface Icd10Categories {
   category: string
   description: string
@@ -1866,6 +1877,7 @@ export interface DB {
   health_worker_licence_revocations: HealthWorkerLicenceRevocations
   health_worker_licences: HealthWorkerLicences
   health_worker_web_notifications: HealthWorkerWebNotifications
+  health_worker_web_push_subscriptions: HealthWorkerWebPushSubscriptions
   health_workers: HealthWorkers
   icd10_categories: Icd10Categories
   icd10_codes: Icd10Codes

--- a/db/migrations/20260605120000_notify_health_worker_notification_inserted.ts
+++ b/db/migrations/20260605120000_notify_health_worker_notification_inserted.ts
@@ -1,0 +1,29 @@
+import { Kysely, sql } from 'kysely'
+import type { DB } from '../../db.d.ts'
+
+export async function up(db: Kysely<DB>) {
+  await sql`
+    CREATE OR REPLACE FUNCTION notify_health_worker_notification_inserted()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      PERFORM pg_notify('health_worker_notification_inserted', json_build_object(
+        'id', NEW.id,
+        'health_worker_id', NEW.health_worker_id
+      )::text);
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  `.execute(db)
+
+  await sql`
+    CREATE TRIGGER health_worker_notification_inserted_trigger
+    AFTER INSERT ON health_worker_web_notifications
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_health_worker_notification_inserted();
+  `.execute(db)
+}
+
+export async function down(db: Kysely<DB>) {
+  await sql`DROP TRIGGER IF EXISTS health_worker_notification_inserted_trigger ON health_worker_web_notifications`.execute(db)
+  await sql`DROP FUNCTION IF EXISTS notify_health_worker_notification_inserted`.execute(db)
+}

--- a/db/migrations/20260610090049_health_worker_web_push_subscriptions.ts
+++ b/db/migrations/20260610090049_health_worker_web_push_subscriptions.ts
@@ -1,0 +1,38 @@
+import type { DB } from '../../db.d.ts'
+import { Kysely } from 'kysely'
+import { createStandardTable } from '../createTable.ts'
+
+export async function up(db: Kysely<DB>) {
+  await createStandardTable(
+    db,
+    'health_worker_web_push_subscriptions',
+    (qb) =>
+      qb
+        .addColumn(
+          'health_worker_id',
+          'uuid',
+          (col) => col.notNull().references('health_workers.id').onDelete('cascade'),
+        )
+        .addColumn('endpoint', 'text', (col) => col.notNull())
+        .addColumn('p256dh', 'text', (col) => col.notNull())
+        .addColumn('auth', 'text', (col) => col.notNull())
+        .addColumn('user_agent', 'text')
+        .addUniqueConstraint(
+          'unique_health_worker_web_push_subscription_endpoint',
+          ['endpoint'],
+        ),
+  )
+
+  await db.schema
+    .createIndex('idx_health_worker_web_push_subscriptions_health_worker_id')
+    .on('health_worker_web_push_subscriptions')
+    .column('health_worker_id')
+    .execute()
+}
+
+export async function down(db: Kysely<DB>) {
+  await db.schema
+    .dropIndex('idx_health_worker_web_push_subscriptions_health_worker_id')
+    .execute()
+  await db.schema.dropTable('health_worker_web_push_subscriptions').execute()
+}

--- a/db/models/health_worker_web_push_subscriptions.ts
+++ b/db/models/health_worker_web_push_subscriptions.ts
@@ -1,0 +1,65 @@
+import type { DB } from '../../db.d.ts'
+import { SelectShape, TrxOrDb } from '../../types.ts'
+
+type HealthWorkerWebPushSubscription = SelectShape<
+  DB['health_worker_web_push_subscriptions']
+>
+
+export const health_worker_web_push_subscriptions = {
+  upsertForHealthWorker(
+    trx: TrxOrDb,
+    {
+      health_worker_id,
+      endpoint,
+      p256dh,
+      auth,
+      user_agent,
+    }: {
+      health_worker_id: string
+      endpoint: string
+      p256dh: string
+      auth: string
+      user_agent?: string
+    },
+  ): Promise<HealthWorkerWebPushSubscription> {
+    return trx
+      .insertInto('health_worker_web_push_subscriptions')
+      .values({
+        health_worker_id,
+        endpoint,
+        p256dh,
+        auth,
+        user_agent: user_agent ?? null,
+      })
+      .onConflict((oc) =>
+        oc.column('endpoint').doUpdateSet({
+          health_worker_id,
+          p256dh,
+          auth,
+          user_agent: user_agent ?? null,
+        })
+      )
+      .returningAll()
+      .executeTakeFirstOrThrow()
+  },
+  listByHealthWorkerId(
+    trx: TrxOrDb,
+    { health_worker_id }: { health_worker_id: string },
+  ): Promise<HealthWorkerWebPushSubscription[]> {
+    return trx
+      .selectFrom('health_worker_web_push_subscriptions')
+      .selectAll()
+      .where('health_worker_id', '=', health_worker_id)
+      .orderBy('created_at', 'asc')
+      .execute()
+  },
+  deleteByEndpoint(
+    trx: TrxOrDb,
+    { endpoint }: { endpoint: string },
+  ) {
+    return trx
+      .deleteFrom('health_worker_web_push_subscriptions')
+      .where('endpoint', '=', endpoint)
+      .execute()
+  },
+}

--- a/db/models/notifications.ts
+++ b/db/models/notifications.ts
@@ -1,10 +1,106 @@
 import { sql } from 'kysely'
+import { Client } from 'pg'
 import { isPriority, ORDERED_PRIORITIES, Priority, PRIORITY_SNOMED_CODES } from '../../shared/priorities.ts'
 import { NonEmptyArray, PostgresInterval, RenderedNotification, TrxOrDb, TrxOrDbOrQueryCreator } from '../../types.ts'
 import { orderByArrayPosition } from '../helpers.ts'
 import { timeAgoDisplay } from '../../util/timeAgoDisplay.ts'
 import { base } from './_base.ts'
 import { assertOr400 } from '../../util/assertOr.ts'
+import { opts } from '../db.ts'
+import { assert } from 'std/assert/assert.ts'
+import { isUUID } from '../../util/uuid.ts'
+import { exists } from '../../util/exists.ts'
+import assertHasProperty from '../../util/assertHasProperty.ts'
+
+const _PUBSUB_GLOBAL_KEY = '__vha_notificationsPubSub__'
+
+type NotificationsPubSub = {
+  by_health_worker_id: {
+    subscribe(health_worker_id: string, callback: (notification_id: string) => void): void
+    unsubscribe(health_worker_id: string, callback: (notification_id: string) => void): void
+  }
+  shutdown(): Promise<void>
+}
+
+let notifications_pub_sub_promise: Promise<NotificationsPubSub> | undefined
+
+async function createNotificationsPubSub(): Promise<NotificationsPubSub> {
+  const by_health_worker_id_subscribers = new Map<string, Set<(notification_id: string) => void>>()
+
+  const client = new Client(opts || {})
+  await client.connect()
+  await client.query(`LISTEN health_worker_notification_inserted`)
+
+  const on_notification = (event: { channel?: string; payload?: string }) => {
+    if (event.channel !== 'health_worker_notification_inserted') return
+    assert(event.payload)
+    const notification = JSON.parse(event.payload)
+    assertHasProperty(notification, 'id')
+    assertHasProperty(notification, 'health_worker_id')
+    assert(isUUID(notification.id))
+    assert(isUUID(notification.health_worker_id))
+    const subscriptions = by_health_worker_id_subscribers.get(notification.health_worker_id)
+    if (!subscriptions?.size) return
+    for (const subscription of subscriptions) {
+      subscription(notification.id)
+    }
+  }
+  client.on('notification', on_notification)
+
+  return {
+    by_health_worker_id: {
+      subscribe(health_worker_id: string, callback: (notification_id: string) => void) {
+        assert(isUUID(health_worker_id))
+        if (!by_health_worker_id_subscribers.has(health_worker_id)) {
+          by_health_worker_id_subscribers.set(health_worker_id, new Set())
+        }
+        const subscriptions = exists(by_health_worker_id_subscribers.get(health_worker_id))
+        subscriptions.add(callback)
+      },
+      unsubscribe(health_worker_id: string, callback: (notification_id: string) => void) {
+        assert(isUUID(health_worker_id))
+        const subscriptions = by_health_worker_id_subscribers.get(health_worker_id)
+        subscriptions?.delete(callback)
+        if (!subscriptions?.size) {
+          by_health_worker_id_subscribers.delete(health_worker_id)
+        }
+      },
+    },
+    async shutdown() {
+      by_health_worker_id_subscribers.clear()
+      client.removeListener('notification', on_notification)
+      client.removeAllListeners('notification')
+      try {
+        await client.query('UNLISTEN health_worker_notification_inserted')
+      } catch {
+        // Connection may already be closing.
+      }
+      await client.end()
+    },
+  }
+}
+
+async function initializeNotificationsPubSubImpl(): Promise<NotificationsPubSub> {
+  // deno-lint-ignore no-explicit-any
+  const existing = (globalThis as any)[_PUBSUB_GLOBAL_KEY] as NotificationsPubSub | undefined
+  if (existing) return existing
+
+  notifications_pub_sub_promise ||= createNotificationsPubSub().then((instance) => {
+    // deno-lint-ignore no-explicit-any
+    ;(globalThis as any)[_PUBSUB_GLOBAL_KEY] = instance
+    return instance
+  })
+  return await notifications_pub_sub_promise
+}
+
+const initialize_notifications_pub_sub = Object.assign(
+  initializeNotificationsPubSubImpl,
+  {
+    get called() {
+      return !!notifications_pub_sub_promise
+    },
+  },
+)
 
 // Deceased is in ORDERED_PRIORITIES but is not assigned as a live encounter triage level.
 const ENCOUNTER_ORDERED_PRIORITIES = ORDERED_PRIORITIES.filter(
@@ -22,7 +118,7 @@ type Terms = {
   recent_first?: boolean
 }
 
-export const notifications = base({
+const notifications_base = base({
   top_level_table: 'health_worker_web_notifications',
   baseQuery(trx, terms: Terms) {
     assertOr400(terms.health_worker_id)
@@ -182,5 +278,18 @@ export const notifications = base({
 
     const priority = row?.encounter_priority
     return priority && isPriority(priority) ? priority : null
+  },
+})
+
+export const notifications = Object.assign(notifications_base, {
+  initializeNotificationsPubSub: initialize_notifications_pub_sub,
+  async closeNotificationsPubSub(opts: { graceful: boolean }) {
+    assert(!opts.graceful, 'TODO support a graceful mode')
+    if (!notifications_pub_sub_promise) return
+    const pub_sub = await notifications_pub_sub_promise
+    await pub_sub.shutdown()
+    // deno-lint-ignore no-explicit-any
+    delete (globalThis as any)[_PUBSUB_GLOBAL_KEY]
+    notifications_pub_sub_promise = undefined
   },
 })

--- a/deno.json
+++ b/deno.json
@@ -56,7 +56,7 @@
     "rules:rebuild:prod": "deno task prod db:seed recreate 31_rules",
     "dummyx": "triggerdockerrebuild"
   },
-  "compilerOptions": { 
+  "compilerOptions": {
     "lib": [
       "dom",
       "dom.asynciterable",
@@ -139,6 +139,7 @@
     "fresh": "jsr:@fresh/core@2.3.3",
     "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@1.1.2",
     "s-expression": "npm:s-expression@3.1.1",
+    "web-push": "npm:web-push@3.6.7",
     "vite": "npm:vite@^7.1.3",
     "tailwindcss": "npm:tailwindcss@4.1.18",
     "tailwindcss/plugin": "npm:/tailwindcss@4.1.10/plugin.js",

--- a/deno.json
+++ b/deno.json
@@ -139,7 +139,7 @@
     "fresh": "jsr:@fresh/core@2.3.3",
     "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@1.1.2",
     "s-expression": "npm:s-expression@3.1.1",
-    "web-push": "npm:web-push@3.6.7",
+    "@negrel/webpush": "jsr:@negrel/webpush@0.5.0",
     "vite": "npm:vite@^7.1.3",
     "tailwindcss": "npm:tailwindcss@4.1.18",
     "tailwindcss/plugin": "npm:/tailwindcss@4.1.10/plugin.js",

--- a/deno.lock
+++ b/deno.lock
@@ -14,11 +14,15 @@
     "jsr:@fresh/core@2.3.3": "2.3.3",
     "jsr:@fresh/core@^2.3.3": "2.3.3",
     "jsr:@fresh/plugin-vite@1.1.2": "1.1.2",
+    "jsr:@negrel/http-ece@0.7.0": "0.7.0",
+    "jsr:@negrel/webpush@0.5.0": "0.5.0",
     "jsr:@std/assert@~1.0.6": "1.0.19",
+    "jsr:@std/bytes@1": "1.0.6",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/cli@0.224.7": "0.224.7",
     "jsr:@std/dotenv@~0.225.5": "0.225.6",
     "jsr:@std/dotenv@~0.225.6": "0.225.6",
+    "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
     "jsr:@std/encoding@~1.0.5": "1.0.10",
     "jsr:@std/fmt@*": "1.0.10",
@@ -192,6 +196,21 @@
         "npm:vite@^7.1.4"
       ]
     },
+    "@negrel/http-ece@0.7.0": {
+      "integrity": "068e61ba6f52da5454051a283cc19621607f8dd6e74d55c01bb365b8c6644076",
+      "dependencies": [
+        "jsr:@std/bytes@1",
+        "jsr:@std/encoding@1"
+      ]
+    },
+    "@negrel/webpush@0.5.0": {
+      "integrity": "919ed5bf4d676923667c5278093f36ffb2efe7fe2f155b6d32723ea3b73fa693",
+      "dependencies": [
+        "jsr:@negrel/http-ece",
+        "jsr:@std/bytes@1",
+        "jsr:@std/encoding@1"
+      ]
+    },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e"
     },
@@ -268,7 +287,7 @@
     "@std/uuid@1.1.0": {
       "integrity": "6268db2ccf172849c9be80763354ca305d49ef4af41fe995623d44fcc3f7457c",
       "dependencies": [
-        "jsr:@std/bytes"
+        "jsr:@std/bytes@^1.0.6"
       ]
     }
   },
@@ -3463,6 +3482,7 @@
       "jsr:@deno/loader@0.5.0",
       "jsr:@fresh/core@2.3.3",
       "jsr:@fresh/plugin-vite@1.1.2",
+      "jsr:@negrel/webpush@0.5.0",
       "jsr:@std/cli@0.224.7",
       "jsr:@std/dotenv@~0.225.6",
       "jsr:@std/fs@^1.0.23",
@@ -3500,7 +3520,6 @@
       "npm:tailwindcss@4.1.18",
       "npm:tiny-lru@11.4.5",
       "npm:vite@^7.1.3",
-      "npm:web-push@3.6.7",
       "npm:zod@4.2.1"
     ]
   }

--- a/deno.lock
+++ b/deno.lock
@@ -3500,6 +3500,7 @@
       "npm:tailwindcss@4.1.18",
       "npm:tiny-lru@11.4.5",
       "npm:vite@^7.1.3",
+      "npm:web-push@3.6.7",
       "npm:zod@4.2.1"
     ]
   }

--- a/external-clients/web-push-config.ts
+++ b/external-clients/web-push-config.ts
@@ -1,0 +1,18 @@
+import { readMandatoryStringEnvironmentVariable } from '../util/env.ts'
+
+export const vapid_public_key = readMandatoryStringEnvironmentVariable(
+  'VAPID_PUBLIC_KEY',
+)
+
+export const vapid_private_key = readMandatoryStringEnvironmentVariable(
+  'VAPID_PRIVATE_KEY',
+)
+
+export const vapid_subject = readMandatoryStringEnvironmentVariable(
+  'VAPID_SUBJECT',
+)
+
+export const vapid_server_config = {
+  private_key: vapid_private_key,
+  subject: vapid_subject,
+}

--- a/external-clients/web-push.ts
+++ b/external-clients/web-push.ts
@@ -1,52 +1,5 @@
+import { ApplicationServer, importVapidKeys, PushMessageError } from '@negrel/webpush'
 import { vapid_public_key, vapid_server_config } from './web-push-config.ts'
-
-type WebPushSendOptions = {
-  TTL: number
-}
-
-type WebPushClient = {
-  setVapidDetails(subject: string, publicKey: string, privateKey: string): void
-  sendNotification(
-    subscription: ReturnType<typeof webPushSubscriptionFromRow>,
-    payload: string,
-    options?: WebPushSendOptions,
-  ): Promise<void>
-}
-
-let webpush_promise: Promise<WebPushClient> | undefined
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
-}
-
-function webPushClientFromModule(mod: unknown): WebPushClient {
-  if (!isObject(mod)) throw new Error('web-push module must be an object')
-  const candidate = isObject(mod.default) ? mod.default : mod
-  const setVapidDetails = candidate.setVapidDetails
-  const sendNotification = candidate.sendNotification
-  if (typeof setVapidDetails !== 'function') throw new Error('web-push module missing setVapidDetails')
-  if (typeof sendNotification !== 'function') throw new Error('web-push module missing sendNotification')
-  return {
-    setVapidDetails: (subject, publicKey, privateKey) => setVapidDetails(subject, publicKey, privateKey),
-    sendNotification: (subscription, payload, options) => sendNotification(subscription, payload, options),
-  }
-}
-
-async function getWebPushClient(): Promise<WebPushClient> {
-  if (!webpush_promise) {
-    webpush_promise = (async () => {
-      const mod = await import(/* @vite-ignore */ 'web-push')
-      const webpush = webPushClientFromModule(mod)
-      webpush.setVapidDetails(
-        vapid_server_config.subject,
-        vapid_public_key,
-        vapid_server_config.private_key,
-      )
-      return webpush
-    })()
-  }
-  return webpush_promise
-}
 
 export type WebPushNotificationPayload = {
   title: string
@@ -77,15 +30,74 @@ export function webPushSubscriptionFromRow({
 
 const EXPIRED_WEB_PUSH_STATUS_CODES = new Set([404, 410])
 
+function webPushStatusCode(error: unknown): number | undefined {
+  if (error instanceof PushMessageError) return error.response.status
+  if (error && typeof error === 'object' && 'statusCode' in error) {
+    const { statusCode } = error as { statusCode: unknown }
+    if (typeof statusCode === 'number') return statusCode
+  }
+  return undefined
+}
+
 export function isExpiredWebPushSubscriptionError(error: unknown): boolean {
-  if (!error || typeof error !== 'object' || !('statusCode' in error)) return false
-  const { statusCode } = error
-  return typeof statusCode === 'number' && EXPIRED_WEB_PUSH_STATUS_CODES.has(statusCode)
+  const status = webPushStatusCode(error)
+  return status !== undefined && EXPIRED_WEB_PUSH_STATUS_CODES.has(status)
 }
 
 export type SendWebPushNotificationResult =
   | { ok: true }
   | { ok: false; error: unknown; expired_subscription: boolean }
+
+// @negrel/webpush wants VAPID keys as a CryptoKeyPair imported from JWK, but our
+// env vars hold the keys as base64url-encoded raw bytes (RFC 8292 format): the
+// public key is the 65-byte uncompressed P-256 point, the private key the 32-byte
+// scalar. Convert to JWK so importVapidKeys can build the CryptoKeyPair.
+function base64UrlToBytes(value: string): Uint8Array {
+  const padding = '='.repeat((4 - (value.length % 4)) % 4)
+  const base64 = (value + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return bytes
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+let application_server_promise: Promise<ApplicationServer> | undefined
+
+function getApplicationServer(): Promise<ApplicationServer> {
+  if (!application_server_promise) {
+    application_server_promise = (async () => {
+      const publicBytes = base64UrlToBytes(vapid_public_key) // 0x04 || x(32) || y(32)
+      const x = bytesToBase64Url(publicBytes.slice(1, 33))
+      const y = bytesToBase64Url(publicBytes.slice(33, 65))
+      const vapidKeys = await importVapidKeys({
+        publicKey: { kty: 'EC', crv: 'P-256', x, y, ext: true },
+        privateKey: {
+          kty: 'EC',
+          crv: 'P-256',
+          x,
+          y,
+          d: vapid_server_config.private_key,
+          ext: true,
+        },
+      })
+      return ApplicationServer.new({
+        contactInformation: vapid_server_config.subject,
+        vapidKeys,
+      })
+    })().catch((error) => {
+      // Don't cache a failed init; let the next send retry.
+      application_server_promise = undefined
+      throw error
+    })
+  }
+  return application_server_promise
+}
 
 export async function sendWebPushNotification({
   endpoint,
@@ -94,12 +106,9 @@ export async function sendWebPushNotification({
   payload,
 }: WebPushSubscriptionInput & { payload: WebPushNotificationPayload }): Promise<SendWebPushNotificationResult> {
   try {
-    const webpush = await getWebPushClient()
-    await webpush.sendNotification(
-      webPushSubscriptionFromRow({ endpoint, p256dh, auth }),
-      JSON.stringify(payload),
-      { TTL: 60 },
-    )
+    const app_server = await getApplicationServer()
+    const subscriber = app_server.subscribe(webPushSubscriptionFromRow({ endpoint, p256dh, auth }))
+    await subscriber.pushTextMessage(JSON.stringify(payload), { ttl: 60 })
     return { ok: true }
   } catch (error) {
     return {

--- a/external-clients/web-push.ts
+++ b/external-clients/web-push.ts
@@ -1,0 +1,17 @@
+import { readMandatoryStringEnvironmentVariable } from '../util/env.ts'
+
+export const vapid_public_key = readMandatoryStringEnvironmentVariable(
+  'VAPID_PUBLIC_KEY',
+)
+
+const vapid_private_key = readMandatoryStringEnvironmentVariable(
+  'VAPID_PRIVATE_KEY',
+)
+const vapid_subject = readMandatoryStringEnvironmentVariable(
+  'VAPID_SUBJECT',
+)
+
+export const vapid_server_config = {
+  private_key: vapid_private_key,
+  subject: vapid_subject,
+}

--- a/external-clients/web-push.ts
+++ b/external-clients/web-push.ts
@@ -1,3 +1,4 @@
+import webpush from 'web-push'
 import { readMandatoryStringEnvironmentVariable } from '../util/env.ts'
 
 export const vapid_public_key = readMandatoryStringEnvironmentVariable(
@@ -14,4 +15,70 @@ const vapid_subject = readMandatoryStringEnvironmentVariable(
 export const vapid_server_config = {
   private_key: vapid_private_key,
   subject: vapid_subject,
+}
+
+webpush.setVapidDetails(
+  vapid_server_config.subject,
+  vapid_public_key,
+  vapid_server_config.private_key,
+)
+
+export type WebPushNotificationPayload = {
+  title: string
+  body: string
+  url?: string
+  notification_id?: string
+}
+
+export type WebPushSubscriptionInput = {
+  endpoint: string
+  p256dh: string
+  auth: string
+}
+
+export function webPushSubscriptionFromRow({
+  endpoint,
+  p256dh,
+  auth,
+}: WebPushSubscriptionInput) {
+  return {
+    endpoint,
+    keys: {
+      p256dh,
+      auth,
+    },
+  }
+}
+
+const EXPIRED_WEB_PUSH_STATUS_CODES = new Set([404, 410])
+
+export function isExpiredWebPushSubscriptionError(error: unknown): boolean {
+  if (!error || typeof error !== 'object' || !('statusCode' in error)) return false
+  const { statusCode } = error
+  return typeof statusCode === 'number' && EXPIRED_WEB_PUSH_STATUS_CODES.has(statusCode)
+}
+
+export type SendWebPushNotificationResult =
+  | { ok: true }
+  | { ok: false; error: unknown; expired_subscription: boolean }
+
+export async function sendWebPushNotification({
+  endpoint,
+  p256dh,
+  auth,
+  payload,
+}: WebPushSubscriptionInput & { payload: WebPushNotificationPayload }): Promise<SendWebPushNotificationResult> {
+  try {
+    await webpush.sendNotification(
+      webPushSubscriptionFromRow({ endpoint, p256dh, auth }),
+      JSON.stringify(payload),
+    )
+    return { ok: true }
+  } catch (error) {
+    return {
+      ok: false,
+      error,
+      expired_subscription: isExpiredWebPushSubscriptionError(error),
+    }
+  }
 }

--- a/external-clients/web-push.ts
+++ b/external-clients/web-push.ts
@@ -1,27 +1,44 @@
-import webpush from 'web-push'
-import { readMandatoryStringEnvironmentVariable } from '../util/env.ts'
+import { vapid_public_key, vapid_server_config } from './web-push-config.ts'
 
-export const vapid_public_key = readMandatoryStringEnvironmentVariable(
-  'VAPID_PUBLIC_KEY',
-)
-
-const vapid_private_key = readMandatoryStringEnvironmentVariable(
-  'VAPID_PRIVATE_KEY',
-)
-const vapid_subject = readMandatoryStringEnvironmentVariable(
-  'VAPID_SUBJECT',
-)
-
-export const vapid_server_config = {
-  private_key: vapid_private_key,
-  subject: vapid_subject,
+type WebPushClient = {
+  setVapidDetails(subject: string, publicKey: string, privateKey: string): void
+  sendNotification(subscription: ReturnType<typeof webPushSubscriptionFromRow>, payload: string): Promise<void>
 }
 
-webpush.setVapidDetails(
-  vapid_server_config.subject,
-  vapid_public_key,
-  vapid_server_config.private_key,
-)
+let webpush_promise: Promise<WebPushClient> | undefined
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function webPushClientFromModule(mod: unknown): WebPushClient {
+  if (!isObject(mod)) throw new Error('web-push module must be an object')
+  const candidate = isObject(mod.default) ? mod.default : mod
+  const setVapidDetails = candidate.setVapidDetails
+  const sendNotification = candidate.sendNotification
+  if (typeof setVapidDetails !== 'function') throw new Error('web-push module missing setVapidDetails')
+  if (typeof sendNotification !== 'function') throw new Error('web-push module missing sendNotification')
+  return {
+    setVapidDetails: (subject, publicKey, privateKey) => setVapidDetails.call(candidate, subject, publicKey, privateKey),
+    sendNotification: (subscription, payload) => sendNotification.call(candidate, subscription, payload),
+  }
+}
+
+async function getWebPushClient(): Promise<WebPushClient> {
+  if (!webpush_promise) {
+    webpush_promise = (async () => {
+      const mod = await import(/* @vite-ignore */ 'web-push')
+      const webpush = webPushClientFromModule(mod)
+      webpush.setVapidDetails(
+        vapid_server_config.subject,
+        vapid_public_key,
+        vapid_server_config.private_key,
+      )
+      return webpush
+    })()
+  }
+  return webpush_promise
+}
 
 export type WebPushNotificationPayload = {
   title: string
@@ -69,6 +86,7 @@ export async function sendWebPushNotification({
   payload,
 }: WebPushSubscriptionInput & { payload: WebPushNotificationPayload }): Promise<SendWebPushNotificationResult> {
   try {
+    const webpush = await getWebPushClient()
     await webpush.sendNotification(
       webPushSubscriptionFromRow({ endpoint, p256dh, auth }),
       JSON.stringify(payload),

--- a/external-clients/web-push.ts
+++ b/external-clients/web-push.ts
@@ -1,8 +1,16 @@
 import { vapid_public_key, vapid_server_config } from './web-push-config.ts'
 
+type WebPushSendOptions = {
+  TTL: number
+}
+
 type WebPushClient = {
   setVapidDetails(subject: string, publicKey: string, privateKey: string): void
-  sendNotification(subscription: ReturnType<typeof webPushSubscriptionFromRow>, payload: string): Promise<void>
+  sendNotification(
+    subscription: ReturnType<typeof webPushSubscriptionFromRow>,
+    payload: string,
+    options?: WebPushSendOptions,
+  ): Promise<void>
 }
 
 let webpush_promise: Promise<WebPushClient> | undefined
@@ -19,8 +27,8 @@ function webPushClientFromModule(mod: unknown): WebPushClient {
   if (typeof setVapidDetails !== 'function') throw new Error('web-push module missing setVapidDetails')
   if (typeof sendNotification !== 'function') throw new Error('web-push module missing sendNotification')
   return {
-    setVapidDetails: (subject, publicKey, privateKey) => setVapidDetails.call(candidate, subject, publicKey, privateKey),
-    sendNotification: (subscription, payload) => sendNotification.call(candidate, subscription, payload),
+    setVapidDetails: (subject, publicKey, privateKey) => setVapidDetails(subject, publicKey, privateKey),
+    sendNotification: (subscription, payload, options) => sendNotification(subscription, payload, options),
   }
 }
 
@@ -90,6 +98,7 @@ export async function sendWebPushNotification({
     await webpush.sendNotification(
       webPushSubscriptionFromRow({ endpoint, p256dh, auth }),
       JSON.stringify(payload),
+      { TTL: 60 },
     )
     return { ok: true }
   } catch (error) {

--- a/islands/notifications/EnableWebPushNotifications.tsx
+++ b/islands/notifications/EnableWebPushNotifications.tsx
@@ -89,7 +89,8 @@ export function EnableWebPushNotifications() {
         level: 'success',
         message: 'Push notifications enabled. You will receive alerts when you are away from this page.',
       })
-    } catch {
+    } catch (error) {
+      console.error(error)
       showAlertMessage({
         level: 'error',
         message: 'Could not enable push notifications. Please try again.',

--- a/islands/notifications/EnableWebPushNotifications.tsx
+++ b/islands/notifications/EnableWebPushNotifications.tsx
@@ -1,0 +1,118 @@
+import { useSignal } from '@preact/signals'
+import { Button } from '../../components/library/Button.tsx'
+import { showAlertMessage } from '../alert/AlertListener.tsx'
+
+function browserSupportsWebPush() {
+  return 'Notification' in window &&
+    'serviceWorker' in navigator &&
+    'PushManager' in window
+}
+
+function urlBase64ToUint8Array(base64_string: string) {
+  const padding = '='.repeat((4 - base64_string.length % 4) % 4)
+  const base64 = (base64_string + padding)
+    .replace(/-/g, '+')
+    .replace(/_/g, '/')
+  const raw_data = atob(base64)
+  return Uint8Array.from(raw_data, (char) => char.charCodeAt(0))
+}
+
+export function EnableWebPushNotifications() {
+  const loading = useSignal(false)
+
+  async function enableWebPush() {
+    if (loading.value) return
+    loading.value = true
+
+    try {
+      if (!browserSupportsWebPush()) {
+        showAlertMessage({
+          level: 'error',
+          message: 'Push notifications are not supported in this browser.',
+        })
+        return
+      }
+
+      const registration = await navigator.serviceWorker.register('/service-worker.js')
+
+      const permission = await Notification.requestPermission()
+      if (permission !== 'granted') {
+        showAlertMessage({
+          level: 'warning',
+          message: 'Notification permission was not granted. Enable notifications in your browser settings to receive push alerts.',
+        })
+        return
+      }
+
+      const public_key_response = await fetch('/app/web-push-public-key')
+      if (!public_key_response.ok) {
+        showAlertMessage({
+          level: 'error',
+          message: 'Could not load push notification configuration. Please try again.',
+        })
+        return
+      }
+
+      const { public_key } = await public_key_response.json()
+      if (!public_key) {
+        showAlertMessage({
+          level: 'error',
+          message: 'Push notification configuration is missing. Please contact support.',
+        })
+        return
+      }
+
+      const subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(public_key),
+      })
+
+      const subscription_json = subscription.toJSON()
+      const save_response = await fetch('/app/web-push-subscription', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          endpoint: subscription_json.endpoint,
+          keys: subscription_json.keys,
+        }),
+      })
+
+      if (!save_response.ok) {
+        showAlertMessage({
+          level: 'error',
+          message: 'Could not save your push notification subscription. Please try again.',
+        })
+        return
+      }
+
+      showAlertMessage({
+        level: 'success',
+        message: 'Push notifications enabled. You will receive alerts when you are away from this page.',
+      })
+    } catch {
+      showAlertMessage({
+        level: 'error',
+        message: 'Could not enable push notifications. Please try again.',
+      })
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return (
+    <div className='rounded-lg border border-gray-200 bg-white p-4 shadow'>
+      <p className='text-sm text-gray-600'>
+        Receive alerts on this device when you are not actively using the app.
+      </p>
+      <Button
+        type='button'
+        variant='secondary'
+        className='mt-3'
+        disabled={loading.value}
+        onClick={enableWebPush}
+      >
+        {loading.value ? 'Enabling…' : 'Enable push notifications'}
+      </Button>
+    </div>
+  )
+}

--- a/routes/app/notifications-websocket.ts
+++ b/routes/app/notifications-websocket.ts
@@ -1,5 +1,5 @@
 import { notifications } from '../../db/models/notifications.ts'
-import { LoggedInHealthWorkerContext } from '../../types.ts'
+import { LoggedInHealthWorkerContext, RenderedNotification } from '../../types.ts'
 import upgradeWebsocket from '../../util/websocket.ts'
 import last from '../../util/last.ts'
 
@@ -7,48 +7,56 @@ export default upgradeWebsocket((
   ctx: LoggedInHealthWorkerContext,
   socket: WebSocket,
 ) => {
-  console.log('upgraded websocket')
-  // deno-lint-ignore no-explicit-any
-  let timeout: any
   let past_ts: Date | undefined
+  const health_worker_id = ctx.state.health_worker.id
+  let pub_sub: Awaited<ReturnType<typeof notifications.initializeNotificationsPubSub>> | undefined
 
-  async function loop() {
-    console.log('notifications-websocket loop')
-    notifications.verbose = true
-    const new_notifications = await notifications.findAll(
-      ctx.state.trx,
-      {
-        health_worker_id: ctx.state.health_worker.id,
-        past_ts,
-      },
-    )
-    for (const new_notification of new_notifications) {
-      console.log('new_notification weklewkl', new_notification)
-      if (!past_ts || (new_notification.created_at > past_ts)) {
-        socket.send(JSON.stringify({
-          ...new_notification,
-          type: 'new_notification',
-        }))
-      }
-      past_ts = new_notification.created_at
+  const sendIfNew = (new_notification: RenderedNotification) => {
+    if (!past_ts || (new_notification.created_at > past_ts)) {
+      socket.send(JSON.stringify({
+        ...new_notification,
+        type: 'new_notification',
+      }))
     }
-    timeout = setTimeout(loop, 1000)
+    past_ts = new_notification.created_at
+  }
+
+  const on_notification = async (notification_id: string) => {
+    try {
+      const new_notification = await notifications.getByIdOptional(
+        ctx.state.trx,
+        notification_id,
+        { health_worker_id },
+      )
+      if (!new_notification) return
+      sendIfNew(new_notification)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  const cleanup = () => {
+    pub_sub?.by_health_worker_id.unsubscribe(health_worker_id, on_notification)
   }
 
   socket.onopen = async () => {
+    pub_sub = await notifications.initializeNotificationsPubSub()
+    pub_sub.by_health_worker_id.subscribe(health_worker_id, on_notification)
+
     const notifs = await notifications.findAll(
       ctx.state.trx,
-      {
-        health_worker_id: ctx.state.health_worker.id,
-      },
+      { health_worker_id },
     )
     past_ts = last(notifs)?.created_at
-    await loop()
+
+    const new_notifications = await notifications.findAll(
+      ctx.state.trx,
+      { health_worker_id, past_ts },
+    )
+    for (const new_notification of new_notifications) {
+      sendIfNew(new_notification)
+    }
   }
-  socket.onclose = () => clearTimeout(timeout)
-  socket.onerror = (/* error */) => {
-    // TODO: distinguish between different socket errors?
-    // console.error('SOCKET ERROR:', error)
-    clearTimeout(timeout)
-  }
+  socket.onclose = cleanup
+  socket.onerror = cleanup
 })

--- a/routes/app/notifications.tsx
+++ b/routes/app/notifications.tsx
@@ -5,6 +5,7 @@ import Pagination from '../../components/library/Pagination.tsx'
 import Avatar from '../../components/library/Avatar.tsx'
 import { EmptyState } from '../../components/library/EmptyState.tsx'
 import { BellIcon } from '../../components/library/icons/heroicons/outline.tsx'
+import { EnableWebPushNotifications } from '../../islands/notifications/EnableWebPushNotifications.tsx'
 
 const ROWS_PER_PAGE = 25
 
@@ -25,16 +26,20 @@ export default HealthWorkerHomePage(
 
     if (results.length === 0 && page === 1) {
       return (
-        <EmptyState
-          header='No notifications yet'
-          explanation="When you have notifications, they'll show up here."
-          Icon={BellIcon}
-        />
+        <div className='flex flex-col gap-4'>
+          <EnableWebPushNotifications />
+          <EmptyState
+            header='No notifications yet'
+            explanation="When you have notifications, they'll show up here."
+            Icon={BellIcon}
+          />
+        </div>
       )
     }
 
     return (
       <form method='get' className='flex flex-col gap-4'>
+        <EnableWebPushNotifications />
         <ul role='list' className='divide-y divide-gray-200 bg-white shadow rounded-lg'>
           {results.map((notification) => (
             <NotificationRow

--- a/routes/app/web-push-public-key.ts
+++ b/routes/app/web-push-public-key.ts
@@ -1,0 +1,9 @@
+import { vapid_public_key } from '../../external-clients/web-push.ts'
+import { LoggedInHealthWorkerContext } from '../../types.ts'
+import { json } from '../../util/responses.ts'
+
+export const handler = {
+  GET(_ctx: LoggedInHealthWorkerContext) {
+    return json({ public_key: vapid_public_key })
+  },
+}

--- a/routes/app/web-push-public-key.ts
+++ b/routes/app/web-push-public-key.ts
@@ -1,4 +1,4 @@
-import { vapid_public_key } from '../../external-clients/web-push.ts'
+import { vapid_public_key } from '../../external-clients/web-push-config.ts'
 import { LoggedInHealthWorkerContext } from '../../types.ts'
 import { json } from '../../util/responses.ts'
 

--- a/routes/app/web-push-subscription.ts
+++ b/routes/app/web-push-subscription.ts
@@ -1,0 +1,35 @@
+import z from 'zod'
+import { health_worker_web_push_subscriptions } from '../../db/models/health_worker_web_push_subscriptions.ts'
+import { LoggedInHealthWorkerContext } from '../../types.ts'
+import { parseWithValues } from '../../util/assertMatches.ts'
+import { json } from '../../util/responses.ts'
+
+const WebPushSubscriptionSchema = z.object({
+  endpoint: z.string().min(1),
+  keys: z.object({
+    p256dh: z.string().min(1),
+    auth: z.string().min(1),
+  }).strict(),
+}).strict()
+
+export const handler = {
+  async POST(ctx: LoggedInHealthWorkerContext) {
+    const { endpoint, keys } = parseWithValues(
+      WebPushSubscriptionSchema,
+      await ctx.req.json(),
+    )
+
+    await health_worker_web_push_subscriptions.upsertForHealthWorker(
+      ctx.state.trx,
+      {
+        health_worker_id: ctx.state.health_worker_id,
+        endpoint,
+        p256dh: keys.p256dh,
+        auth: keys.auth,
+        user_agent: ctx.req.headers.get('user-agent') ?? undefined,
+      },
+    )
+
+    return json({ ok: true })
+  },
+}

--- a/routes/app/web-push-test.ts
+++ b/routes/app/web-push-test.ts
@@ -1,0 +1,70 @@
+import { sendWebPushNotification } from '../../external-clients/web-push.ts'
+import { health_worker_web_push_subscriptions } from '../../db/models/health_worker_web_push_subscriptions.ts'
+import { LoggedInHealthWorkerContext } from '../../types.ts'
+import { json } from '../../util/responses.ts'
+
+function webPushSendErrorSummary(error: unknown): string {
+  if (!error || typeof error !== 'object') return String(error)
+
+  const summary: Record<string, unknown> = {}
+  if ('name' in error && typeof error.name === 'string') summary.name = error.name
+  if ('message' in error && typeof error.message === 'string') summary.message = error.message
+  if ('statusCode' in error && typeof error.statusCode === 'number') summary.statusCode = error.statusCode
+  if ('body' in error) summary.body = error.body
+  if ('headers' in error) summary.headers = error.headers
+
+  return Object.keys(summary).length ? JSON.stringify(summary) : String(error)
+}
+
+export const handler = {
+  async POST(ctx: LoggedInHealthWorkerContext) {
+    const subscriptions = await health_worker_web_push_subscriptions.listByHealthWorkerId(
+      ctx.state.trx,
+      { health_worker_id: ctx.state.health_worker_id },
+    )
+
+    let sent = 0
+    let failed = 0
+    let deleted_expired = 0
+    const failed_errors: string[] = []
+
+    for (const subscription of subscriptions) {
+      const result = await sendWebPushNotification({
+        endpoint: subscription.endpoint,
+        p256dh: subscription.p256dh,
+        auth: subscription.auth,
+        payload: {
+          title: 'Test VHA notification',
+          body: 'Web push notifications are working.',
+          url: '/app/notifications',
+        },
+      })
+
+      if (result.ok) {
+        sent++
+        continue
+      }
+
+      if (result.expired_subscription) {
+        await health_worker_web_push_subscriptions.deleteByEndpoint(
+          ctx.state.trx,
+          { endpoint: subscription.endpoint },
+        )
+        deleted_expired++
+        continue
+      }
+
+      failed++
+      failed_errors.push(webPushSendErrorSummary(result.error))
+    }
+
+    return json({
+      ok: true,
+      subscriptions: subscriptions.length,
+      sent,
+      failed,
+      deleted_expired,
+      failed_errors,
+    })
+  },
+}

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,0 +1,46 @@
+addEventListener('push', (event) => {
+  var title = 'New VHA notification'
+  var body = 'You have a new notification.'
+  var url = '/app/notifications'
+  var notification_id
+
+  if (event.data) {
+    var payload
+    try {
+      payload = event.data.json()
+    } catch (_e) {
+      body = event.data.text()
+      payload = null
+    }
+
+    if (payload) {
+      if (payload.title) title = payload.title
+      if (payload.body) body = payload.body
+      if (payload.url) url = payload.url
+      if (payload.notification_id) notification_id = payload.notification_id
+    }
+  }
+
+  var data = { url }
+  if (notification_id) data.notification_id = notification_id
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      data,
+    }),
+  )
+})
+
+addEventListener('notificationclick', (event) => {
+  event.notification.close()
+
+  var url = event.notification.data?.url || '/app/notifications'
+
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((window_clients) => {
+      if (window_clients.length) return window_clients[0].focus()
+      return clients.openWindow(url)
+    }),
+  )
+})

--- a/test/models/health_worker_web_push_subscriptions.test.ts
+++ b/test/models/health_worker_web_push_subscriptions.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'std/testing/bdd.ts'
+import { assertEquals } from 'std/assert/assert_equals.ts'
+import db from '../../db/db.ts'
+import { health_worker_web_push_subscriptions } from '../../db/models/health_worker_web_push_subscriptions.ts'
+import { addTestEmployee } from '../_helpers/employees.ts'
+
+describe('db/models/health_worker_web_push_subscriptions.ts', () => {
+  it('upserts, lists, and deletes subscriptions by endpoint', async () => {
+    const health_worker = await addTestEmployee(db, { role: 'nurse' })
+    const endpoint = 'https://push.example.test/subscription/1'
+
+    const subscription = await health_worker_web_push_subscriptions.upsertForHealthWorker(
+      db,
+      {
+        health_worker_id: health_worker.id,
+        endpoint,
+        p256dh: 'test-p256dh',
+        auth: 'test-auth',
+        user_agent: 'test-agent',
+      },
+    )
+
+    assertEquals(subscription.endpoint, endpoint)
+    assertEquals(subscription.health_worker_id, health_worker.id)
+
+    const updated = await health_worker_web_push_subscriptions.upsertForHealthWorker(
+      db,
+      {
+        health_worker_id: health_worker.id,
+        endpoint,
+        p256dh: 'updated-p256dh',
+        auth: 'updated-auth',
+      },
+    )
+
+    assertEquals(updated.id, subscription.id)
+    assertEquals(updated.p256dh, 'updated-p256dh')
+    assertEquals(updated.auth, 'updated-auth')
+    assertEquals(updated.user_agent, null)
+
+    const listed = await health_worker_web_push_subscriptions.listByHealthWorkerId(db, {
+      health_worker_id: health_worker.id,
+    })
+
+    assertEquals(listed.length, 1)
+    assertEquals(listed[0]?.endpoint, endpoint)
+
+    await health_worker_web_push_subscriptions.deleteByEndpoint(db, { endpoint })
+
+    assertEquals(
+      await health_worker_web_push_subscriptions.listByHealthWorkerId(db, {
+        health_worker_id: health_worker.id,
+      }),
+      [],
+    )
+  })
+})

--- a/test/models/notifications.test.ts
+++ b/test/models/notifications.test.ts
@@ -1,0 +1,52 @@
+import { afterAll, before, describe, it } from 'std/testing/bdd.ts'
+import { assertEquals } from 'std/assert/assert_equals.ts'
+import db from '../../db/db.ts'
+import { notifications } from '../../db/models/notifications.ts'
+import { addTestEmployee } from '../_helpers/employees.ts'
+import { timeout } from '../../util/timeout.ts'
+
+describe('db/models/notifications.ts', () => {
+  before(async () => {
+    await notifications.initializeNotificationsPubSub()
+  })
+  afterAll(async () => {
+    await notifications.closeNotificationsPubSub({ graceful: false })
+    await db.destroy()
+  })
+
+  describe('initializeNotificationsPubSub', () => {
+    it(
+      'notifies subscribers when a notification is inserted',
+      async () => {
+        const health_worker = await addTestEmployee(db, { role: 'nurse' })
+        const pub_sub = await notifications.initializeNotificationsPubSub()
+        const received = Promise.withResolvers<string>()
+        const callback = (notification_id: string) => received.resolve(notification_id)
+        pub_sub.by_health_worker_id.subscribe(health_worker.id, callback)
+
+        try {
+          const { id } = await notifications.insert(db, {
+            health_worker_id: health_worker.id,
+            title: 'Test notification',
+            description: 'Test description',
+            avatar_url: '/images/test.svg',
+            table_name: 'patient_encounters',
+            row_id: '00000000-0000-1000-8000-000000000099',
+            notification_type: 'test',
+            action_title: 'View',
+            action_href: '/app',
+          })
+
+          const timer = timeout(5000)
+          try {
+            assertEquals(await Promise.race([received.promise, timer]), id)
+          } finally {
+            timer.cancel()
+          }
+        } finally {
+          pub_sub.by_health_worker_id.unsubscribe(health_worker.id, callback)
+        }
+      },
+    )
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,11 @@ export default defineConfig({
       'preact/debug': 'preact',
     },
   },
+  ssr: {
+    // web-push and asn1.js are CommonJS; bundling them for SSR breaks with
+    // "ReferenceError: exports is not defined". Load via Deno/npm at runtime.
+    external: ['web-push', 'asn1.js'],
+  },
   server: {
     port: parseInt(PORT, 10),
     // // Tell Vite's HMR client to connect through the HTTPS proxy rather than

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,11 +17,6 @@ export default defineConfig({
       'preact/debug': 'preact',
     },
   },
-  ssr: {
-    // web-push and asn1.js are CommonJS; bundling them for SSR breaks with
-    // "ReferenceError: exports is not defined". Load via Deno/npm at runtime.
-    external: ['web-push', 'asn1.js'],
-  },
   server: {
     port: parseInt(PORT, 10),
     // // Tell Vite's HMR client to connect through the HTTPS proxy rather than


### PR DESCRIPTION
## Summary

Implemented the initial Web Push notification flow for health workers.

This PR allows a logged-in health worker to enable browser push notifications from /app/notifications, stores their browser PushSubscription, and adds a server-side path for sending test push notifications through web-push.

## What changed

### Backend

- Added a health_worker_web_push_subscriptions table to store browser push subscriptions.
- Added model helpers to:
  - upsert a subscription by endpoint
  - list subscriptions by health_worker_id
  - delete expired subscriptions
- Added GET /app/web-push-public-key to expose the VAPID public key to the client.
- Added POST /app/web-push-subscription to save the logged-in health worker’s browser subscription.
- Added external-clients/web-push.ts for sending Web Push notifications with npm:web-push.
- Added POST /app/web-push-test as an authenticated test route for verifying the push flow.
- Added TTL: 60 to test push sends so debug notifications are not queued for too long.
- Added Vite SSR externalization for web-push / asn1.js to avoid CommonJS SSR issues in dev.

### Frontend

- Added static/service-worker.js.
  - Handles push events.
  - Calls showNotification().
  - Opens or focuses /app/notifications when a notification is clicked.
- Added an “Enable push notifications” button on /app/notifications.
  - Registers the service worker.
  - Requests notification permission.
  - Creates a browser PushSubscription.
  - Sends the subscription to the server.

## Validation

Tested locally on:

http://localhost:8001/app/notifications 

Verified:

- GET /app/web-push-public-key returns the VAPID public key.
- POST /app/web-push-subscription saves a browser push subscription.
- The DB row is created in health_worker_web_push_subscriptions.
- The saved DB subscription matches the browser subscription:
  - endpoint
  - p256dh
  - auth
- Notification.permission === "granted".
- The service worker is active.
- Direct service-worker notification display works.
- POST /app/web-push-test successfully sends a test push payload to the saved subscription.
- End-to-end push was verified in Safari: the service worker received the push event and macOS displayed the notification banner.

Test response:

json {   "ok": true,   "subscriptions": 1,   "sent": 1,   "failed": 0,   "deleted_expired": 0,   "failed_errors": [] } 

## Notes

Chrome local testing successfully sent the payload to the push service and returned sent: 1, but the local Chrome profile did not consistently fire the service worker push event. Safari confirmed the full end-to-end Web Push path, including service worker delivery and macOS notification display.

<img width="3000" height="1578" alt="image" src="https://github.com/user-attachments/assets/9a5d0269-174c-41f3-87ea-6e094532cfab" />
<img width="361" height="121" alt="Screenshot 2026-06-10 at 2 52 35 AM" src="https://github.com/user-attachments/assets/fc1f5709-5570-4f49-80e6-0d2cc71fb96c" />


## Remaining work

- Wire sendWebPushNotification into real VHA notification creation flows, such as urgent triage or case referral notifications.
- Remove or guard /app/web-push-test before production use, since it is intended for local/debug verification.