### PR TITLE
Fix realtime notification bubble updates

### DIFF
--- a/db/migrations/20250110030806_notifications.ts
+++ b/db/migrations/20250110030806_notifications.ts
@@ -1,4 +1,3 @@
-
 import type { DB } from '../../db.d.ts'
 import { Kysely } from 'kysely'
 import { createStandardTable } from '../createTable.ts'

--- a/islands/NotificationBubble.tsx
+++ b/islands/NotificationBubble.tsx
@@ -5,11 +5,15 @@ import cls from '../util/cls.ts'
 
 export function NotificationBubble(props: { count: number; priority: Priority | null }) {
   const count = useSignal(props.count)
-  const colors = priorityColors(props.priority)
+  const priority = useSignal<Priority | null>(props.priority)
+  const colors = priorityColors(priority.value)
 
   useEffect(() => {
-    function listener() {
-      count.value++
+    function listener(event: Event) {
+      if (!(event instanceof CustomEvent)) return
+      if (event.detail?.type !== 'notification_summary') return
+      count.value = event.detail.unread_count
+      priority.value = event.detail.highest_priority
     }
     self.addEventListener('notification', listener)
     return () => {

--- a/islands/Notifications.tsx
+++ b/islands/Notifications.tsx
@@ -20,8 +20,8 @@ export function Notifications(
 
   useEffect(() => {
     function listener(event: Event) {
-      console.log('notification event', event)
       assert(event instanceof CustomEvent)
+      if (event.detail?.type !== 'new_notification') return
       notifications_signal.value = [event.detail, ...notifications_signal.value]
     }
     self.addEventListener('notification', listener)

--- a/routes/app/notifications-websocket.ts
+++ b/routes/app/notifications-websocket.ts
@@ -3,60 +3,82 @@ import { LoggedInHealthWorkerContext, RenderedNotification } from '../../types.t
 import upgradeWebsocket from '../../util/websocket.ts'
 import last from '../../util/last.ts'
 
-export default upgradeWebsocket((
-  ctx: LoggedInHealthWorkerContext,
-  socket: WebSocket,
-) => {
-  let past_ts: Date | undefined
-  const health_worker_id = ctx.state.health_worker.id
-  let pub_sub: Awaited<ReturnType<typeof notifications.initializeNotificationsPubSub>> | undefined
+export const handler = {
+  GET: upgradeWebsocket((
+    ctx: LoggedInHealthWorkerContext,
+    socket: WebSocket,
+  ) => {
+    let past_ts: Date | undefined
+    const health_worker_id = ctx.state.health_worker.id
+    let pub_sub: Awaited<ReturnType<typeof notifications.initializeNotificationsPubSub>> | undefined
 
-  const sendIfNew = (new_notification: RenderedNotification) => {
-    if (!past_ts || (new_notification.created_at > past_ts)) {
-      socket.send(JSON.stringify({
-        ...new_notification,
-        type: 'new_notification',
-      }))
+    const sendIfNew = (new_notification: RenderedNotification) => {
+      if (!past_ts || (new_notification.created_at > past_ts)) {
+        socket.send(JSON.stringify({
+          ...new_notification,
+          type: 'new_notification',
+        }))
+      }
+      past_ts = new_notification.created_at
     }
-    past_ts = new_notification.created_at
-  }
 
-  const on_notification = async (notification_id: string) => {
-    try {
-      const new_notification = await notifications.getByIdOptional(
+    const sendNotificationSummary = async () => {
+      if (socket.readyState !== WebSocket.OPEN) return
+      const unread_count = await notifications.countAll(ctx.state.trx, {
+        health_worker_id,
+        only_unread: true,
+      })
+      const highest_priority = await notifications.highestUnreadPriority(
         ctx.state.trx,
-        notification_id,
         { health_worker_id },
       )
-      if (!new_notification) return
-      sendIfNew(new_notification)
-    } catch (error) {
-      console.error(error)
+      socket.send(JSON.stringify({
+        type: 'notification_summary',
+        unread_count,
+        highest_priority,
+      }))
     }
-  }
 
-  const cleanup = () => {
-    pub_sub?.by_health_worker_id.unsubscribe(health_worker_id, on_notification)
-  }
-
-  socket.onopen = async () => {
-    pub_sub = await notifications.initializeNotificationsPubSub()
-    pub_sub.by_health_worker_id.subscribe(health_worker_id, on_notification)
-
-    const notifs = await notifications.findAll(
-      ctx.state.trx,
-      { health_worker_id },
-    )
-    past_ts = last(notifs)?.created_at
-
-    const new_notifications = await notifications.findAll(
-      ctx.state.trx,
-      { health_worker_id, past_ts },
-    )
-    for (const new_notification of new_notifications) {
-      sendIfNew(new_notification)
+    const on_notification = async (notification_id: string) => {
+      try {
+        const new_notification = await notifications.getByIdOptional(
+          ctx.state.trx,
+          notification_id,
+          { health_worker_id },
+        )
+        if (!new_notification) return
+        sendIfNew(new_notification)
+        await sendNotificationSummary()
+      } catch (error) {
+        console.error(error)
+      }
     }
-  }
-  socket.onclose = cleanup
-  socket.onerror = cleanup
-})
+
+    const cleanup = () => {
+      pub_sub?.by_health_worker_id.unsubscribe(health_worker_id, on_notification)
+    }
+
+    socket.onopen = async () => {
+      pub_sub = await notifications.initializeNotificationsPubSub()
+      pub_sub.by_health_worker_id.subscribe(health_worker_id, on_notification)
+
+      const notifs = await notifications.findAll(
+        ctx.state.trx,
+        { health_worker_id },
+      )
+      past_ts = last(notifs)?.created_at
+
+      const new_notifications = await notifications.findAll(
+        ctx.state.trx,
+        { health_worker_id, past_ts },
+      )
+      for (const new_notification of new_notifications) {
+        sendIfNew(new_notification)
+      }
+
+      await sendNotificationSummary()
+    }
+    socket.onclose = cleanup
+    socket.onerror = cleanup
+  }),
+}

--- a/static/scripts/general.js
+++ b/static/scripts/general.js
@@ -184,10 +184,8 @@ addEventListener('submit', function (event) {
             elements = document.querySelectorAll('input[name^="' + path + '"]')
           }
 
-          var message = issue.message === 'Required'
-            ? 'A value must be input'
-            : issue.message
-          
+          var message = issue.message === 'Required' ? 'A value must be input' : issue.message
+
           if (!elements.length) {
             return dispatchEvent(
               new CustomEvent('show-alert', { detail: message }),
@@ -195,9 +193,7 @@ addEventListener('submit', function (event) {
           }
           if (elements.length > 1) {
             var label = document.querySelector('[for="' + path + '"]') || document.querySelector('[for^="' + path + '"]')
-            var detail = label
-              ? label.textContent + ': ' + message
-              : message
+            var detail = label ? label.textContent + ': ' + message : message
             return dispatchEvent(
               new CustomEvent('show-alert', { detail: detail }),
             )
@@ -431,7 +427,6 @@ addEventListener('submit', function (event) {
 //   }
 // })
 
-
 var protocol = self.location.protocol === 'http:' ? 'ws' : 'wss'
 
 var wsUri = protocol + '://' + self.location.host + '/app/notifications-websocket'
@@ -447,45 +442,49 @@ websocket.onclose = function () {
 
 websocket.onmessage = function (e) {
   var message_data = JSON.parse(e.data)
-  console.log('mmmmwelklekw', message_data)
-  if (document.hidden && Notification.permission === 'granted')  {
-    var notification = new Notification(notification_data.title, {
-      body: notification_data.description,
-      icon: notification_data.avatar_url,
-      timestamp: notification_data.created_at,
+  if (
+    message_data.type === 'new_notification' &&
+    document.hidden &&
+    Notification.permission === 'granted'
+  ) {
+    var notification = new Notification(message_data.title, {
+      body: message_data.description,
+      icon: message_data.avatar_url,
+      timestamp: message_data.created_at,
     })
     notification.onclick = function () {
-      window.location.href = notification_data.action.href
+      window.location.href = message_data.action.href
     }
-    return
   }
-  dispatchEvent(new CustomEvent('notification', {
-    detail: message_data
-  }))
+  dispatchEvent(
+    new CustomEvent('notification', {
+      detail: message_data,
+    }),
+  )
 }
 
 websocket.onerror = function (e) {
   console.error(e)
 }
 
-  // console.log(message_data)
-  
-  // // console.log('echo', e.data)
-  // /*
-  // {
-  //     "created_at": notification_data.created_at,
-  //     "updated_at": notification_data.updated_at,
-  //     "health_worker_id": nurse.health_worker.id,
-  //     "notification_type": "patient_encounter_immediate_triage",
-  //     "title": "Immediate Triage Requested",
-  //     "description": `${employeeDisplay(receptionist_employee).display_name} has requested immediate triage for a patient`,
-  //     "avatar_url": "/images/heroicons/24/solid/exclamation-triangle.svg",
-  //     "seen_at": null,
-  //     "notification_id": notification_data.notification_id,
-  //     "time_display": "Just now",
-  //     "action": {
-  //       "title": "View patient case",
-  //       "href": `/app/organizations/${organization.id}/patients/${patient_id}/open_encounter/respond-to-immediate-triage-request`
-  //     }
-  //   }
-  // */  
+// console.log(message_data)
+
+// // console.log('echo', e.data)
+// /*
+// {
+//     "created_at": notification_data.created_at,
+//     "updated_at": notification_data.updated_at,
+//     "health_worker_id": nurse.health_worker.id,
+//     "notification_type": "patient_encounter_immediate_triage",
+//     "title": "Immediate Triage Requested",
+//     "description": `${employeeDisplay(receptionist_employee).display_name} has requested immediate triage for a patient`,
+//     "avatar_url": "/images/heroicons/24/solid/exclamation-triangle.svg",
+//     "seen_at": null,
+//     "notification_id": notification_data.notification_id,
+//     "time_display": "Just now",
+//     "action": {
+//       "title": "View patient case",
+//       "href": `/app/organizations/${organization.id}/patients/${patient_id}/open_encounter/respond-to-immediate-triage-request`
+//     }
+//   }
+// */

--- a/test/models/notifications.test.ts
+++ b/test/models/notifications.test.ts
@@ -5,6 +5,20 @@ import { notifications } from '../../db/models/notifications.ts'
 import { addTestEmployee } from '../_helpers/employees.ts'
 import { timeout } from '../../util/timeout.ts'
 
+function insertTestNotification(health_worker_id: string, row_id: string) {
+  return notifications.insert(db, {
+    health_worker_id,
+    title: 'Test notification',
+    description: 'Test description',
+    avatar_url: '/images/test.svg',
+    table_name: 'patient_encounters',
+    row_id,
+    notification_type: 'test',
+    action_title: 'View',
+    action_href: '/app',
+  })
+}
+
 describe('db/models/notifications.ts', () => {
   before(async () => {
     await notifications.initializeNotificationsPubSub()
@@ -101,6 +115,80 @@ describe('db/models/notifications.ts', () => {
           pub_sub.by_health_worker_id.unsubscribe(health_worker.id, throwingCallback)
           pub_sub.by_health_worker_id.unsubscribe(health_worker.id, succeedingCallback)
         }
+      },
+    )
+  })
+
+  describe('notification summary data sources', () => {
+    it(
+      'countAll only_unread reflects unread notifications and excludes seen ones',
+      async () => {
+        const health_worker = await addTestEmployee(db, { role: 'nurse' })
+
+        assertEquals(
+          await notifications.countAll(db, {
+            health_worker_id: health_worker.id,
+            only_unread: true,
+          }),
+          0,
+        )
+
+        const first = await insertTestNotification(
+          health_worker.id,
+          '00000000-0000-1000-8000-000000000091',
+        )
+        await insertTestNotification(
+          health_worker.id,
+          '00000000-0000-1000-8000-000000000092',
+        )
+
+        assertEquals(
+          await notifications.countAll(db, {
+            health_worker_id: health_worker.id,
+            only_unread: true,
+          }),
+          2,
+        )
+
+        await db
+          .updateTable('health_worker_web_notifications')
+          .set({ seen_at: new Date() })
+          .where('id', '=', first.id)
+          .execute()
+
+        assertEquals(
+          await notifications.countAll(db, {
+            health_worker_id: health_worker.id,
+            only_unread: true,
+          }),
+          1,
+        )
+      },
+    )
+
+    it(
+      'highestUnreadPriority returns null when there are no unread encounter-linked notifications',
+      async () => {
+        const health_worker = await addTestEmployee(db, { role: 'nurse' })
+
+        assertEquals(
+          await notifications.highestUnreadPriority(db, {
+            health_worker_id: health_worker.id,
+          }),
+          null,
+        )
+
+        await insertTestNotification(
+          health_worker.id,
+          '00000000-0000-1000-8000-000000000093',
+        )
+
+        assertEquals(
+          await notifications.highestUnreadPriority(db, {
+            health_worker_id: health_worker.id,
+          }),
+          null,
+        )
       },
     )
   })

--- a/types.ts
+++ b/types.ts
@@ -2065,6 +2065,20 @@ export type RenderedNotification = {
   }
 }
 
+export type NewNotificationMessage = RenderedNotification & {
+  type: 'new_notification'
+}
+
+export type NotificationSummaryMessage = {
+  type: 'notification_summary'
+  unread_count: number
+  highest_priority: Priority | null
+}
+
+export type NotificationWebSocketMessage =
+  | NewNotificationMessage
+  | NotificationSummaryMessage
+
 export type ChatbotName = 'patient' | 'pharmacist'
 
 export type UnhandledMessage = {

--- a/util/websocket.ts
+++ b/util/websocket.ts
@@ -17,18 +17,15 @@ export default function upgradeWebsocket<State>(
   return async function (
     ctx: Context<State>,
   ) {
-    console.log('foo bar')
     assert(
       isWebsocketPath(ctx),
       'Route must follow the convention that websocket routes end in websocket. This is used to determine whether to open a transaction or not.',
     )
-    console.log('baz bing')
     assertOr400(
       ctx.req.headers.get('upgrade') === 'websocket',
       'Only websocket connections supported',
     )
 
-    console.log('ok true')
     const { socket, response } = Deno.upgradeWebSocket(ctx.req)
     callback(ctx, socket)
     return response


### PR DESCRIPTION
## What changed

- Update the notification bubble count in real time
- Update the bubble color based on the highest unread priority
- Add a notification_summary WebSocket message with the latest count and priority
- Keep new_notification for the notification list and browser notification
- Fix the notification WebSocket route to use a Fresh GET handler
- Add tests for unread count and priority behavior

## Testing

Manually tested the nurse-to-doctor referral flow:

- count updates without refreshing
- color updates without opening the Notifications tab
- multiple notifications keep the correct count and highest priority

Verified using:

bash deno task build && deno task preview 

The preview step is required for testing WebSocket changes, as discussed.