### PR TITLE
Add read receipts for health worker notifications

### DIFF
--- a/db/models/notifications.ts
+++ b/db/models/notifications.ts
@@ -290,6 +290,24 @@ export const notifications = base({
     const priority = row?.encounter_priority
     return priority && isPriority(priority) ? priority : null
   },
+  async markSeen(
+    trx: TrxOrDb,
+    { health_worker_id, notification_ids }: {
+      health_worker_id: string
+      notification_ids: string[]
+    },
+  ): Promise<number> {
+    assertOr400(health_worker_id)
+    if (!notification_ids.length) return 0
+    const result = await trx
+      .updateTable('health_worker_web_notifications')
+      .set({ seen_at: new Date() })
+      .where('health_worker_id', '=', health_worker_id)
+      .where('id', 'in', notification_ids)
+      .where('seen_at', 'is', null)
+      .executeTakeFirst()
+    return Number(result.numUpdatedRows)
+  },
   async initializeNotificationsPubSub(): Promise<NotificationsPubSub> {
     // deno-lint-ignore no-explicit-any
     const existing = (globalThis as any)[_PUBSUB_GLOBAL_KEY] as NotificationsPubSub | undefined

--- a/islands/Notifications.tsx
+++ b/islands/Notifications.tsx
@@ -6,6 +6,7 @@ import { useSignal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { assert } from 'std/assert/assert.ts'
 import { Fragment } from 'preact'
+import { markNotificationsSeen } from './notifications/markNotificationsSeen.ts'
 
 /* NOTIFICATIONS SUBSCRIPTION */
 
@@ -69,6 +70,15 @@ export function Notification(
     dismiss: () => void
   },
 ) {
+  function markSeenOnActivate() {
+    void markNotificationsSeen(notification.notification_id, { keepalive: true })
+  }
+
+  function handleActionAuxClick(event: MouseEvent) {
+    if (event.button !== 1) return
+    markSeenOnActivate()
+  }
+
   return (
     <div className='flex self-end float-right w-full max-w-md bg-white rounded-lg shadow-lg pointer-events-auto ring-1 ring-black ring-opacity-5 z-9'>
       <div className='flex-1 w-0 p-4'>
@@ -95,6 +105,8 @@ export function Notification(
               type='button'
               className='flex items-center justify-center w-full px-4 py-3 text-sm font-medium text-indigo-600 border border-transparent rounded-none rounded-tr-lg hover:text-indigo-500 focus:z-10 focus:outline-none focus:ring-2 focus:ring-indigo-500'
               href={notification.action.href}
+              onClick={markSeenOnActivate}
+              onAuxClick={handleActionAuxClick}
             >
               {notification.action.title}
             </a>

--- a/islands/notifications/MarkPageNotificationsSeen.tsx
+++ b/islands/notifications/MarkPageNotificationsSeen.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'preact/hooks'
+import { NotificationSummaryMessage } from '../../types.ts'
+
+export function MarkPageNotificationsSeen(
+  { notification_ids }: { notification_ids: string[] },
+) {
+  const ids = useRef(notification_ids)
+
+  useEffect(() => {
+    const notification_ids = ids.current
+    if (!notification_ids.length) return
+
+    async function markPageNotificationsSeen() {
+      try {
+        const response = await fetch('/app/notifications/seen', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ notification_ids }),
+        })
+        if (!response.ok) return
+
+        const data = await response.json()
+        if (!data?.ok) return
+
+        const detail: NotificationSummaryMessage = {
+          type: 'notification_summary',
+          unread_count: data.unread_count,
+          highest_priority: data.highest_priority,
+        }
+        self.dispatchEvent(new CustomEvent('notification', { detail }))
+      } catch {
+        // Fail quietly; the page remains usable without updated counts.
+      }
+    }
+
+    markPageNotificationsSeen()
+  }, [])
+
+  return null
+}

--- a/islands/notifications/MarkPageNotificationsSeen.tsx
+++ b/islands/notifications/MarkPageNotificationsSeen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'preact/hooks'
-import { NotificationSummaryMessage } from '../../types.ts'
+import { markNotificationsSeen } from './markNotificationsSeen.ts'
 
 export function MarkPageNotificationsSeen(
   { notification_ids }: { notification_ids: string[] },
@@ -7,33 +7,7 @@ export function MarkPageNotificationsSeen(
   const ids = useRef(notification_ids)
 
   useEffect(() => {
-    const notification_ids = ids.current
-    if (!notification_ids.length) return
-
-    async function markPageNotificationsSeen() {
-      try {
-        const response = await fetch('/app/notifications/seen', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ notification_ids }),
-        })
-        if (!response.ok) return
-
-        const data = await response.json()
-        if (!data?.ok) return
-
-        const detail: NotificationSummaryMessage = {
-          type: 'notification_summary',
-          unread_count: data.unread_count,
-          highest_priority: data.highest_priority,
-        }
-        self.dispatchEvent(new CustomEvent('notification', { detail }))
-      } catch {
-        // Fail quietly; the page remains usable without updated counts.
-      }
-    }
-
-    markPageNotificationsSeen()
+    void markNotificationsSeen(ids.current)
   }, [])
 
   return null

--- a/islands/notifications/NotificationSeenLink.tsx
+++ b/islands/notifications/NotificationSeenLink.tsx
@@ -1,0 +1,34 @@
+import { ComponentChildren } from 'preact'
+import { markNotificationsSeen } from './markNotificationsSeen.ts'
+
+export function NotificationSeenLink({
+  notification_id,
+  href,
+  children,
+  className,
+}: {
+  notification_id: string
+  href: string
+  children: ComponentChildren
+  className?: string
+}) {
+  function markSeenOnActivate() {
+    void markNotificationsSeen(notification_id, { keepalive: true })
+  }
+
+  function handleAuxClick(event: MouseEvent) {
+    if (event.button !== 1) return
+    markSeenOnActivate()
+  }
+
+  return (
+    <a
+      href={href}
+      className={className}
+      onClick={markSeenOnActivate}
+      onAuxClick={handleAuxClick}
+    >
+      {children}
+    </a>
+  )
+}

--- a/islands/notifications/markNotificationsSeen.ts
+++ b/islands/notifications/markNotificationsSeen.ts
@@ -1,0 +1,32 @@
+import { NotificationSummaryMessage } from '../../types.ts'
+
+export async function markNotificationsSeen(
+  notification_ids: string | string[],
+  { keepalive = false }: { keepalive?: boolean } = {},
+): Promise<boolean> {
+  const ids = Array.isArray(notification_ids) ? notification_ids : [notification_ids]
+  if (!ids.length) return false
+
+  try {
+    const response = await fetch('/app/notifications/seen', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notification_ids: ids }),
+      keepalive,
+    })
+    if (!response.ok) return false
+
+    const data = await response.json()
+    if (!data?.ok) return false
+
+    const detail: NotificationSummaryMessage = {
+      type: 'notification_summary',
+      unread_count: data.unread_count,
+      highest_priority: data.highest_priority,
+    }
+    self.dispatchEvent(new CustomEvent('notification', { detail }))
+    return true
+  } catch {
+    return false
+  }
+}

--- a/routes/app/notifications.tsx
+++ b/routes/app/notifications.tsx
@@ -8,6 +8,7 @@ import { BellIcon } from '../../components/library/icons/heroicons/outline.tsx'
 import { vapid_public_key } from '../../external-clients/web-push-config.ts'
 import { EnableWebPushNotifications } from '../../islands/notifications/EnableWebPushNotifications.tsx'
 import { MarkPageNotificationsSeen } from '../../islands/notifications/MarkPageNotificationsSeen.tsx'
+import { NotificationSeenLink } from '../../islands/notifications/NotificationSeenLink.tsx'
 
 const ROWS_PER_PAGE = 25
 
@@ -70,12 +71,13 @@ function NotificationRow(
         <p className='mt-1 text-sm text-gray-500'>{notification.description}</p>
         <p className='mt-1 text-xs text-gray-400'>{notification.time_display}</p>
       </div>
-      <a
+      <NotificationSeenLink
+        notification_id={notification.notification_id}
         href={notification.action.href}
         className='text-sm font-medium text-indigo-600 hover:text-indigo-500 whitespace-nowrap'
       >
         {notification.action.title}
-      </a>
+      </NotificationSeenLink>
     </li>
   )
 }

--- a/routes/app/notifications.tsx
+++ b/routes/app/notifications.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from '../../components/library/EmptyState.tsx'
 import { BellIcon } from '../../components/library/icons/heroicons/outline.tsx'
 import { vapid_public_key } from '../../external-clients/web-push-config.ts'
 import { EnableWebPushNotifications } from '../../islands/notifications/EnableWebPushNotifications.tsx'
+import { MarkPageNotificationsSeen } from '../../islands/notifications/MarkPageNotificationsSeen.tsx'
 
 const ROWS_PER_PAGE = 25
 
@@ -38,9 +39,12 @@ export default HealthWorkerHomePage(
       )
     }
 
+    const notification_ids = results.map((notification) => notification.notification_id)
+
     return (
       <form method='get' className='flex flex-col gap-4'>
         <EnableWebPushNotifications vapid_public_key={vapid_public_key} />
+        {notification_ids.length > 0 && <MarkPageNotificationsSeen notification_ids={notification_ids} />}
         <ul role='list' className='divide-y divide-gray-200 bg-white shadow rounded-lg'>
           {results.map((notification) => (
             <NotificationRow

--- a/routes/app/notifications/seen.ts
+++ b/routes/app/notifications/seen.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+import { notifications } from '../../../db/models/notifications.ts'
+import { LoggedInHealthWorkerContext } from '../../../types.ts'
+import { promiseProps } from '../../../util/promiseProps.ts'
+import { json } from '../../../util/responses.ts'
+
+const MarkNotificationsSeenSchema = z.object({
+  notification_ids: z.array(z.string().uuid()).min(1),
+}).strict()
+
+export const handler = {
+  async POST(ctx: LoggedInHealthWorkerContext) {
+    const { notification_ids } = MarkNotificationsSeenSchema.parse(
+      await ctx.req.json(),
+    )
+    const { trx, health_worker_id } = ctx.state
+
+    const marked_count = await notifications.markSeen(trx, {
+      health_worker_id,
+      notification_ids,
+    })
+
+    const { unread_count, highest_priority } = await promiseProps({
+      unread_count: notifications.countAll(trx, {
+        health_worker_id,
+        only_unread: true,
+      }),
+      highest_priority: notifications.highestUnreadPriority(trx, {
+        health_worker_id,
+      }),
+    })
+
+    return json({
+      ok: true,
+      marked_count,
+      unread_count,
+      highest_priority,
+    })
+  },
+}

--- a/test/models/notifications.test.ts
+++ b/test/models/notifications.test.ts
@@ -119,6 +119,145 @@ describe('db/models/notifications.ts', () => {
     )
   })
 
+  describe('markSeen', () => {
+    it('marks unread notifications belonging to the specified health worker', async () => {
+      const health_worker = await addTestEmployee(db, { role: 'nurse' })
+      const first = await insertTestNotification(
+        health_worker.id,
+        '00000000-0000-1000-8000-000000000081',
+      )
+      const second = await insertTestNotification(
+        health_worker.id,
+        '00000000-0000-1000-8000-000000000082',
+      )
+
+      const updated = await notifications.markSeen(db, {
+        health_worker_id: health_worker.id,
+        notification_ids: [first.id, second.id],
+      })
+      assertEquals(updated, 2)
+
+      const rows = await db
+        .selectFrom('health_worker_web_notifications')
+        .select(['id', 'seen_at'])
+        .where('id', 'in', [first.id, second.id])
+        .execute()
+      assertEquals(rows.every((row) => row.seen_at !== null), true)
+    })
+
+    it("does not mark another health worker's notification", async () => {
+      const health_worker = await addTestEmployee(db, { role: 'nurse' })
+      const other_health_worker = await addTestEmployee(db, { role: 'nurse' })
+      const others = await insertTestNotification(
+        other_health_worker.id,
+        '00000000-0000-1000-8000-000000000083',
+      )
+
+      const updated = await notifications.markSeen(db, {
+        health_worker_id: health_worker.id,
+        notification_ids: [others.id],
+      })
+      assertEquals(updated, 0)
+
+      const row = await db
+        .selectFrom('health_worker_web_notifications')
+        .select('seen_at')
+        .where('id', '=', others.id)
+        .executeTakeFirstOrThrow()
+      assertEquals(row.seen_at, null)
+    })
+
+    it('does not overwrite an existing seen_at', async () => {
+      const health_worker = await addTestEmployee(db, { role: 'nurse' })
+      const notification = await insertTestNotification(
+        health_worker.id,
+        '00000000-0000-1000-8000-000000000084',
+      )
+      const already_seen_at = new Date('2020-01-01T00:00:00Z')
+      await db
+        .updateTable('health_worker_web_notifications')
+        .set({ seen_at: already_seen_at })
+        .where('id', '=', notification.id)
+        .execute()
+
+      const updated = await notifications.markSeen(db, {
+        health_worker_id: health_worker.id,
+        notification_ids: [notification.id],
+      })
+      assertEquals(updated, 0)
+
+      const row = await db
+        .selectFrom('health_worker_web_notifications')
+        .select('seen_at')
+        .where('id', '=', notification.id)
+        .executeTakeFirstOrThrow()
+      assertEquals(row.seen_at, already_seen_at)
+    })
+
+    it('is idempotent when called twice', async () => {
+      const health_worker = await addTestEmployee(db, { role: 'nurse' })
+      const notification = await insertTestNotification(
+        health_worker.id,
+        '00000000-0000-1000-8000-000000000085',
+      )
+
+      const first_call = await notifications.markSeen(db, {
+        health_worker_id: health_worker.id,
+        notification_ids: [notification.id],
+      })
+      assertEquals(first_call, 1)
+
+      const second_call = await notifications.markSeen(db, {
+        health_worker_id: health_worker.id,
+        notification_ids: [notification.id],
+      })
+      assertEquals(second_call, 0)
+    })
+
+    it('returns 0 for an empty notification_ids array', async () => {
+      const health_worker = await addTestEmployee(db, { role: 'nurse' })
+
+      const updated = await notifications.markSeen(db, {
+        health_worker_id: health_worker.id,
+        notification_ids: [],
+      })
+      assertEquals(updated, 0)
+    })
+
+    it('countAll only_unread reflects notifications marked as seen', async () => {
+      const health_worker = await addTestEmployee(db, { role: 'nurse' })
+      const first = await insertTestNotification(
+        health_worker.id,
+        '00000000-0000-1000-8000-000000000086',
+      )
+      await insertTestNotification(
+        health_worker.id,
+        '00000000-0000-1000-8000-000000000087',
+      )
+
+      assertEquals(
+        await notifications.countAll(db, {
+          health_worker_id: health_worker.id,
+          only_unread: true,
+        }),
+        2,
+      )
+
+      await notifications.markSeen(db, {
+        health_worker_id: health_worker.id,
+        notification_ids: [first.id],
+      })
+
+      assertEquals(
+        await notifications.countAll(db, {
+          health_worker_id: health_worker.id,
+          only_unread: true,
+        }),
+        1,
+      )
+    })
+  })
+
   describe('notification summary data sources', () => {
     it(
       'countAll only_unread reflects unread notifications and excludes seen ones',

--- a/test/web/notifications/seen.test.ts
+++ b/test/web/notifications/seen.test.ts
@@ -1,0 +1,213 @@
+import { afterAll, before } from 'std/testing/bdd.ts'
+import { assert } from 'std/assert/assert.ts'
+import { assertEquals } from 'std/assert/assert_equals.ts'
+import db from '../../../db/db.ts'
+import { notifications } from '../../../db/models/notifications.ts'
+import { addTestEmployeeWithSession } from 'test/_helpers/employees.ts'
+import { createTestOrganization } from 'test/_helpers/organizations.ts'
+import { describeParallel, itParallel } from 'test/_helpers/testParallel.ts'
+import waitUntilTestServerUp from 'test/_helpers/waitUntilTestServerUp.ts'
+import { route } from '../../_route.ts'
+
+const SEEN_URL = '/app/notifications/seen'
+
+async function setupWorker() {
+  const organization = await createTestOrganization(db)
+  return addTestEmployeeWithSession(db, { role: 'nurse', organization_id: organization.id })
+}
+
+function insertTestNotification(health_worker_id: string, row_id: string) {
+  return notifications.insert(db, {
+    health_worker_id,
+    title: 'Test notification',
+    description: 'Test description',
+    avatar_url: '/images/test.svg',
+    table_name: 'patient_encounters',
+    row_id,
+    notification_type: 'test',
+    action_title: 'View',
+    action_href: '/app',
+  })
+}
+
+function postSeen(
+  fetchWithSession: (input: string, init?: RequestInit) => ReturnType<typeof fetch>,
+  body: unknown,
+  { expectedTestError }: { expectedTestError?: boolean } = {},
+) {
+  return fetchWithSession(
+    expectedTestError ? `${SEEN_URL}?expectedTestError=1` : SEEN_URL,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  )
+}
+
+async function seenAt(notification_id: string) {
+  const row = await db
+    .selectFrom('health_worker_web_notifications')
+    .select('seen_at')
+    .where('id', '=', notification_id)
+    .executeTakeFirstOrThrow()
+  return row.seen_at
+}
+
+describeParallel(SEEN_URL, () => {
+  before(waitUntilTestServerUp)
+  afterAll(() => db.destroy())
+
+  itParallel("marks the authenticated worker's own unread notification", async () => {
+    const { fetchJSON, health_worker } = await setupWorker()
+    const first = await insertTestNotification(health_worker.id, '00000000-0000-1000-8000-000000000071')
+    await insertTestNotification(health_worker.id, '00000000-0000-1000-8000-000000000072')
+
+    const result = await fetchJSON(SEEN_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ notification_ids: [first.id] }),
+    })
+
+    assertEquals(result.ok, true)
+    assertEquals(result.marked_count, 1)
+    assertEquals(result.unread_count, 1)
+    assert((await seenAt(first.id)) !== null)
+  })
+
+  itParallel('does not inflate marked_count when duplicate ids are sent', async () => {
+    const { fetchJSON, health_worker } = await setupWorker()
+    const notification = await insertTestNotification(health_worker.id, '00000000-0000-1000-8000-000000000073')
+
+    const result = await fetchJSON(SEEN_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ notification_ids: [notification.id, notification.id] }),
+    })
+
+    assertEquals(result.marked_count, 1)
+    assertEquals(result.unread_count, 0)
+  })
+
+  itParallel("does not mark another worker's notification and reveals nothing about it", async () => {
+    const owner = await setupWorker()
+    const other = await setupWorker()
+    const foreign = await insertTestNotification(other.health_worker.id, '00000000-0000-1000-8000-000000000074')
+
+    const result = await owner.fetchJSON(SEEN_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ notification_ids: [foreign.id] }),
+    })
+
+    assertEquals(result.ok, true)
+    assertEquals(result.marked_count, 0)
+    assertEquals(await seenAt(foreign.id), null)
+  })
+
+  itParallel('does not overwrite an already-seen notification', async () => {
+    const { fetchJSON, health_worker } = await setupWorker()
+    const notification = await insertTestNotification(health_worker.id, '00000000-0000-1000-8000-000000000075')
+    const already_seen_at = new Date('2020-01-01T00:00:00Z')
+    await db
+      .updateTable('health_worker_web_notifications')
+      .set({ seen_at: already_seen_at })
+      .where('id', '=', notification.id)
+      .execute()
+
+    const result = await fetchJSON(SEEN_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ notification_ids: [notification.id] }),
+    })
+
+    assertEquals(result.marked_count, 0)
+    assertEquals(await seenAt(notification.id), already_seen_at)
+  })
+
+  itParallel('counts only owned unread rows when ids are mixed', async () => {
+    const owner = await setupWorker()
+    const other = await setupWorker()
+
+    const owned_unread = await insertTestNotification(owner.health_worker.id, '00000000-0000-1000-8000-000000000076')
+    const owned_seen = await insertTestNotification(owner.health_worker.id, '00000000-0000-1000-8000-000000000077')
+    const foreign = await insertTestNotification(other.health_worker.id, '00000000-0000-1000-8000-000000000078')
+    const nonexistent = '00000000-0000-1000-8000-0000000000ff'
+    await db
+      .updateTable('health_worker_web_notifications')
+      .set({ seen_at: new Date() })
+      .where('id', '=', owned_seen.id)
+      .execute()
+
+    const result = await owner.fetchJSON(SEEN_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        notification_ids: [owned_unread.id, owned_seen.id, foreign.id, nonexistent],
+      }),
+    })
+
+    assertEquals(result.marked_count, 1)
+    assertEquals(await seenAt(foreign.id), null)
+  })
+
+  itParallel('returns the recalculated highest_priority after marking', async () => {
+    const { fetchJSON, health_worker } = await setupWorker()
+    const notification = await insertTestNotification(health_worker.id, '00000000-0000-1000-8000-000000000079')
+
+    const result = await fetchJSON(SEEN_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ notification_ids: [notification.id] }),
+    })
+
+    assertEquals(result.unread_count, 0)
+    assertEquals(result.highest_priority, null)
+  })
+
+  itParallel('rejects an invalid uuid', async () => {
+    const { fetch: fetchWithSession } = await setupWorker()
+    const response = await postSeen(fetchWithSession, { notification_ids: ['not-a-uuid'] }, {
+      expectedTestError: true,
+    })
+    assertEquals(response.status, 400)
+    await response.body?.cancel()
+  })
+
+  itParallel('rejects an empty notification_ids array', async () => {
+    const { fetch: fetchWithSession } = await setupWorker()
+    const response = await postSeen(fetchWithSession, { notification_ids: [] }, {
+      expectedTestError: true,
+    })
+    assertEquals(response.status, 400)
+    await response.body?.cancel()
+  })
+
+  itParallel('rejects a missing notification_ids field', async () => {
+    const { fetch: fetchWithSession } = await setupWorker()
+    const response = await postSeen(fetchWithSession, {}, { expectedTestError: true })
+    assertEquals(response.status, 400)
+    await response.body?.cancel()
+  })
+
+  itParallel('rejects unknown fields', async () => {
+    const { fetch: fetchWithSession } = await setupWorker()
+    const response = await postSeen(fetchWithSession, {
+      notification_ids: ['00000000-0000-1000-8000-0000000000aa'],
+      extra: true,
+    }, { expectedTestError: true })
+    assertEquals(response.status, 400)
+    await response.body?.cancel()
+  })
+
+  itParallel('redirects an unauthenticated request', async () => {
+    const response = await fetch(`${route}${SEEN_URL}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ notification_ids: ['00000000-0000-1000-8000-0000000000aa'] }),
+      redirect: 'manual',
+    })
+    assertEquals(response.status, 302)
+    await response.body?.cancel()
+  })
+})


### PR DESCRIPTION
## Summary

This adds read receipts for health worker notifications.

Notifications are marked as seen when a health worker:

- opens the notifications page
- clicks a notification action from the page or an in-app toast

## What changed

- Added a model method to update `seen_at` for one or more notifications
- Added `POST /app/notifications/seen`
- Added a small client helper for calling the endpoint and refreshing the sidebar notification count
- Marked notifications on page load after hydration, so the GET route stays read-only
- Marked individual notifications when their action link is clicked

Updates are scoped to the logged-in health worker, and already-seen notifications are left unchanged.

## Testing

Added model and route tests for:

- owned vs. foreign notifications
- already-seen notifications
- repeated requests
- mixed notification IDs
- invalid payloads
- unauthenticated requests
- unread count updates

Also manually verified:

- opening the notifications page sets `seen_at`
- refreshing does not overwrite the timestamp
- clicking a toast action sets `seen_at`
- the unread badge updates correctly

## Notes

This does not include service worker or native browser notification clicks.