### PR TITLE
Reconcile web push subscriptions on load

### DIFF
--- a/islands/notifications/EnableWebPushNotifications.tsx
+++ b/islands/notifications/EnableWebPushNotifications.tsx
@@ -10,6 +10,19 @@ function browserSupportsWebPush() {
     'PushManager' in window
 }
 
+async function persistPushSubscription(subscription: PushSubscription) {
+  const subscription_json = subscription.toJSON()
+  const save_response = await fetch('/app/web-push-subscription', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      endpoint: subscription_json.endpoint,
+      keys: subscription_json.keys,
+    }),
+  })
+  return save_response.ok
+}
+
 async function ensurePushSubscription(
   service_worker: ServiceWorkerRegistration,
   vapid_public_key: string,
@@ -47,20 +60,26 @@ export function EnableWebPushNotifications(
     async function restoreSubscriptionState() {
       try {
         if (!browserSupportsWebPush()) return
+        if (Notification.permission !== 'granted') return
 
         const service_worker = await navigator.serviceWorker.getRegistration()
         if (!service_worker) return
 
         const subscription = await service_worker.pushManager.getSubscription()
         if (
-          Notification.permission === 'granted' &&
-          subscription &&
-          applicationServerKeysMatch(
+          !subscription ||
+          !applicationServerKeysMatch(
             subscription.options.applicationServerKey,
             vapid_public_key,
           )
         ) {
+          return
+        }
+
+        if (await persistPushSubscription(subscription)) {
           enabled.value = true
+        } else {
+          console.error('Could not persist existing push subscription during mount reconciliation')
         }
       } catch (error) {
         console.error(error)
@@ -96,17 +115,7 @@ export function EnableWebPushNotifications(
 
       const subscription = await ensurePushSubscription(service_worker, vapid_public_key)
 
-      const subscription_json = subscription.toJSON()
-      const save_response = await fetch('/app/web-push-subscription', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          endpoint: subscription_json.endpoint,
-          keys: subscription_json.keys,
-        }),
-      })
-
-      if (!save_response.ok) {
+      if (!(await persistPushSubscription(subscription))) {
         showAlertMessage({
           level: 'error',
           message: 'Could not save your push notification subscription. Please try again.',


### PR DESCRIPTION
## Summary

Fixes a case where the UI showed web push notifications as enabled even though the subscription was not saved in the database.

The browser can keep a valid `PushSubscription` after a database rebuild, deleted subscription row, or session change. Previously, the page treated that browser subscription as sufficient and did not re-send it to the backend.

## What changed

- Added a shared helper for persisting a browser push subscription
- Reused that helper during both:
  - page-load reconciliation
  - explicit enablement
- The UI now only shows push notifications as enabled after `POST /app/web-push-subscription` succeeds
- Existing browser subscriptions are re-synced to the backend on page load
- Passive reconciliation failures leave the button available for retry
- User-triggered failures continue to show an error message
- Existing browser subscriptions are preserved when backend persistence fails

## Testing

Ran:

- `deno fmt`
- `deno task check`
- web-push configuration tests
- web-push dispatch tests
- web-push dispatcher initialization tests

Also manually verified:

- an existing browser subscription is persisted again after reload
- a missing database subscription row is recreated
- the browser endpoint matches the endpoint stored in the database
- the UI remains disabled when persistence fails
- the button remains available for retry after failure
- push notifications work after reconciliation
- restarting the local dev server preserves the existing subscription in the current setup

## Notes

During manual testing, Chrome briefly showed its FCM connection as `CONNECTING` with a `SOCKET_FAILURE` in `chrome://gcm-internals`.

This was a transient Chrome-to-Google push service connection issue rather than an application or subscription persistence failure. After restarting Chrome, the connection recovered and push delivery worked normally.

The browser subscription endpoint matched the persisted database row, and the server-side push test reported successful delivery.