### PR TITLE
Improve referral notifications and chart review access

### DIFF
--- a/components/drawer-v4/ThisVisit.tsx
+++ b/components/drawer-v4/ThisVisit.tsx
@@ -22,14 +22,15 @@ function WorkflowSection(
 }
 
 export function DrawerThisVisit(
-  { organization_id, this_visit_findings, this_visit_diagnoses }: {
+  { organization_id, this_visit_findings, this_visit_diagnoses, id = 'patient-drawer-this-visit' }: {
     organization_id: string
     this_visit_findings: RenderedSidebarWorkflow[]
     this_visit_diagnoses: RenderedEvaluationRelativeToHealthWorker[]
+    id?: string
   },
 ) {
   return (
-    <div id='patient-drawer-this-visit' className={section_class_name}>
+    <div id={id} className={section_class_name}>
       <Header>This Visit</Header>
       <div className='flex flex-col gap-2.5'>
         {this_visit_findings.map((workflow) => <WorkflowSection key={workflow.workflow} workflow={workflow} organization_id={organization_id} />)}

--- a/db/models/referrals.ts
+++ b/db/models/referrals.ts
@@ -179,6 +179,8 @@ export const referrals = base({
       originator_health_worker_id,
       originator_avatar_url,
       health_worker_ids_to_be_notified,
+      notification_title,
+      notification_description,
     }: {
       patient_id: string
       patient_encounter_id: string
@@ -187,6 +189,8 @@ export const referrals = base({
       originator_health_worker_id: string
       originator_avatar_url: string
       health_worker_ids_to_be_notified: string[]
+      notification_title?: string
+      notification_description?: string
     },
   ) {
     assertOr400(
@@ -227,8 +231,8 @@ export const referrals = base({
               table_name: 'patient_workflows',
               row_id: procedure_id,
               notification_type: 'case_referral',
-              title: 'Chart review',
-              description: 'A case was referred to you to review',
+              title: notification_title ?? 'Chart review',
+              description: notification_description ?? 'A case was referred to you to review',
               action_title: 'Review Chart',
               action_href: `/app/organizations/${organization_id}/patients/${patient_id}/open_encounter/start-workflow/chart_review`,
               avatar_url: originator_avatar_url,

--- a/db/models/referrals.ts
+++ b/db/models/referrals.ts
@@ -234,7 +234,7 @@ export const referrals = base({
               title: notification_title ?? 'Chart review',
               description: notification_description ?? 'A case was referred to you to review',
               action_title: 'Review Chart',
-              action_href: `/app/organizations/${organization_id}/patients/${patient_id}/open_encounter/start-workflow/chart_review`,
+              action_href: `/app/organizations/${organization_id}/patients/${patient_id}/open_encounter/review_chart`,
               avatar_url: originator_avatar_url,
             }))),
       )

--- a/islands/notifications/NotificationsList.tsx
+++ b/islands/notifications/NotificationsList.tsx
@@ -1,0 +1,84 @@
+import { useEffect } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
+import { assert } from 'std/assert/assert.ts'
+import { RenderedNotification } from '../../types.ts'
+import Avatar from '../../components/library/Avatar.tsx'
+import { EmptyState } from '../../components/library/EmptyState.tsx'
+import { BellIcon } from '../../components/library/icons/heroicons/outline.tsx'
+import { NotificationActionButton } from './NotificationActionButton.tsx'
+import { markNotificationsSeen } from './markNotificationsSeen.ts'
+
+export function NotificationsList(
+  { notifications, page }: {
+    notifications: RenderedNotification[]
+    page: number
+  },
+) {
+  const notifications_signal = useSignal(notifications)
+
+  useEffect(() => {
+    function listener(event: Event) {
+      assert(event instanceof CustomEvent)
+      if (event.detail?.type !== 'new_notification') return
+      if (page !== 1) return
+
+      const notification_id = event.detail.notification_id
+      if (typeof notification_id !== 'string') return
+      if (
+        notifications_signal.value.some((n) => n.notification_id === notification_id)
+      ) {
+        return
+      }
+
+      const { type: _type, ...notification } = event.detail
+      notifications_signal.value = [notification, ...notifications_signal.value]
+      void markNotificationsSeen(notification_id)
+    }
+
+    self.addEventListener('notification', listener)
+    return () => self.removeEventListener('notification', listener)
+  }, [page])
+
+  if (!notifications_signal.value.length) {
+    return (
+      <EmptyState
+        header='No notifications yet'
+        explanation="When you have notifications, they'll show up here."
+        Icon={BellIcon}
+      />
+    )
+  }
+
+  return (
+    <ul role='list' className='divide-y divide-gray-200 bg-white shadow rounded-lg'>
+      {notifications_signal.value.map((notification) => (
+        <NotificationRow
+          key={notification.notification_id}
+          notification={notification}
+        />
+      ))}
+    </ul>
+  )
+}
+
+function NotificationRow(
+  { notification }: { notification: RenderedNotification },
+) {
+  return (
+    <li className='flex items-start gap-4 p-4'>
+      <Avatar src={notification.avatar_url} size='lg' hide_when_empty />
+      <div className='min-w-0 flex-1'>
+        <p className='text-sm font-medium text-gray-900'>{notification.title}</p>
+        <p className='mt-1 text-sm text-gray-500'>{notification.description}</p>
+        <p className='mt-1 text-xs text-gray-400'>{notification.time_display}</p>
+      </div>
+      <NotificationActionButton
+        notification_id={notification.notification_id}
+        href={notification.action.href}
+        className='inline-flex items-center justify-center shrink-0 border border-gray-300 bg-white text-indigo-600 font-semibold rounded-lg hover:border-indigo-600 hover:bg-indigo-50 h-8 px-3 text-sm whitespace-nowrap'
+      >
+        {notification.action.title}
+      </NotificationActionButton>
+    </li>
+  )
+}

--- a/routes/app/notifications.tsx
+++ b/routes/app/notifications.tsx
@@ -1,14 +1,11 @@
-import { LoggedInHealthWorkerContext, RenderedNotification } from '../../types.ts'
+import { LoggedInHealthWorkerContext } from '../../types.ts'
 import { HealthWorkerHomePage } from './_middleware.tsx'
 import { notifications } from '../../db/models/notifications.ts'
 import Pagination from '../../components/library/Pagination.tsx'
-import Avatar from '../../components/library/Avatar.tsx'
-import { EmptyState } from '../../components/library/EmptyState.tsx'
-import { BellIcon } from '../../components/library/icons/heroicons/outline.tsx'
 import { vapid_public_key } from '../../external-clients/web-push-config.ts'
 import { EnableWebPushNotifications } from '../../islands/notifications/EnableWebPushNotifications.tsx'
 import { MarkPageNotificationsSeen } from '../../islands/notifications/MarkPageNotificationsSeen.tsx'
-import { NotificationActionButton } from '../../islands/notifications/NotificationActionButton.tsx'
+import { NotificationsList } from '../../islands/notifications/NotificationsList.tsx'
 
 const ROWS_PER_PAGE = 25
 
@@ -27,57 +24,16 @@ export default HealthWorkerHomePage(
       { page, rows_per_page: ROWS_PER_PAGE },
     )
 
-    if (results.length === 0 && page === 1) {
-      return (
-        <div className='flex flex-col gap-4'>
-          <EnableWebPushNotifications vapid_public_key={vapid_public_key} />
-          <EmptyState
-            header='No notifications yet'
-            explanation="When you have notifications, they'll show up here."
-            Icon={BellIcon}
-          />
-        </div>
-      )
-    }
-
     const notification_ids = results.map((notification) => notification.notification_id)
+    const show_pagination = results.length > 0 || page > 1
 
     return (
       <form method='get' className='flex flex-col gap-4'>
         <EnableWebPushNotifications vapid_public_key={vapid_public_key} />
         {notification_ids.length > 0 && <MarkPageNotificationsSeen notification_ids={notification_ids} />}
-        <ul role='list' className='divide-y divide-gray-200 bg-white shadow rounded-lg'>
-          {results.map((notification) => (
-            <NotificationRow
-              key={notification.notification_id}
-              notification={notification}
-            />
-          ))}
-        </ul>
-        <Pagination page={page} has_next_page={has_next_page} />
+        <NotificationsList notifications={results} page={page} />
+        {show_pagination && <Pagination page={page} has_next_page={has_next_page} />}
       </form>
     )
   },
 )
-
-function NotificationRow(
-  { notification }: { notification: RenderedNotification },
-) {
-  return (
-    <li className='flex items-start gap-4 p-4'>
-      <Avatar src={notification.avatar_url} size='lg' hide_when_empty />
-      <div className='min-w-0 flex-1'>
-        <p className='text-sm font-medium text-gray-900'>{notification.title}</p>
-        <p className='mt-1 text-sm text-gray-500'>{notification.description}</p>
-        <p className='mt-1 text-xs text-gray-400'>{notification.time_display}</p>
-      </div>
-      <NotificationActionButton
-        notification_id={notification.notification_id}
-        href={notification.action.href}
-        className='inline-flex items-center justify-center shrink-0 border border-gray-300 bg-white text-indigo-600 font-semibold rounded-lg hover:border-indigo-600 hover:bg-indigo-50 h-8 px-3 text-sm whitespace-nowrap'
-      >
-        {notification.action.title}
-      </NotificationActionButton>
-    </li>
-  )
-}

--- a/routes/app/notifications.tsx
+++ b/routes/app/notifications.tsx
@@ -74,7 +74,7 @@ function NotificationRow(
       <NotificationActionButton
         notification_id={notification.notification_id}
         href={notification.action.href}
-        className='text-sm font-medium text-indigo-600 hover:text-indigo-500 whitespace-nowrap'
+        className='inline-flex items-center justify-center shrink-0 border border-gray-300 bg-white text-indigo-600 font-semibold rounded-lg hover:border-indigo-600 hover:bg-indigo-50 h-8 px-3 text-sm whitespace-nowrap'
       >
         {notification.action.title}
       </NotificationActionButton>

--- a/routes/app/organizations/[organization_id]/patients/[patient_id]/open_encounter/chart_review/review_case.tsx
+++ b/routes/app/organizations/[organization_id]/patients/[patient_id]/open_encounter/chart_review/review_case.tsx
@@ -2,6 +2,8 @@ import { z } from 'zod'
 import { postHandler } from '../../../../../../../../backend/postHandler.ts'
 import { completeAndProceedToNextStep, OpenEncounterWorkflowPage } from '../_middleware.tsx'
 import type { OpenEncounterWorkflowContext } from '../../../../../../../../types.ts'
+import SectionHeader from '../../../../../../../../components/library/typography/SectionHeader.tsx'
+import { DrawerThisVisit } from '../../../../../../../../components/drawer-v4/ThisVisit.tsx'
 
 const ChartReviewReviewCaseSchema = z.object({})
 
@@ -11,13 +13,31 @@ export const handler = postHandler(
 )
 
 function ChartReviewReviewCasePage(
-  _ctx: OpenEncounterWorkflowContext,
+  ctx: OpenEncounterWorkflowContext,
 ) {
-  // TODO display the case information relevant to the reviewer
+  const {
+    organization_id,
+    this_visit_findings,
+    this_visit_diagnoses,
+    encounter,
+  } = ctx.state
+
   return (
-    <p>
-      TODO: Review the case
-    </p>
+    <div className='flex flex-col gap-6 max-w-3xl'>
+      <SectionHeader>Patient Chart</SectionHeader>
+      <DrawerThisVisit
+        id='chart-review-this-visit'
+        organization_id={organization_id}
+        this_visit_findings={this_visit_findings}
+        this_visit_diagnoses={this_visit_diagnoses}
+      />
+      {encounter.notes && (
+        <div className='flex flex-col gap-2'>
+          <SectionHeader>Notes</SectionHeader>
+          <p className='text-sm text-gray-700'>{encounter.notes}</p>
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/routes/app/organizations/[organization_id]/patients/[patient_id]/open_encounter/review_chart.tsx
+++ b/routes/app/organizations/[organization_id]/patients/[patient_id]/open_encounter/review_chart.tsx
@@ -1,0 +1,111 @@
+import { z } from 'zod'
+import { postHandler } from '../../../../../../../backend/postHandler.ts'
+import redirect from '../../../../../../../util/redirect.ts'
+import { HealthWorkerHomePage } from '../../../../../_middleware.tsx'
+import type { OpenEncounterContext } from '../../../../../../../types.ts'
+import { promiseProps } from '../../../../../../../util/promiseProps.ts'
+import { this_visit_findings } from '../../../../../../../db/models/this_visit_findings.ts'
+import { diagnoses } from '../../../../../../../db/models/diagnoses.ts'
+import { referrals } from '../../../../../../../db/models/referrals.ts'
+import { assertOr403 } from '../../../../../../../util/assertOr.ts'
+import SectionHeader from '../../../../../../../components/library/typography/SectionHeader.tsx'
+import { DrawerThisVisit } from '../../../../../../../components/drawer-v4/ThisVisit.tsx'
+import { Button } from '../../../../../../../components/library/Button.tsx'
+import PriorityBadge from '../../../../../../../components/PriorityBadge.tsx'
+import first from '../../../../../../../util/first.ts'
+
+const ReviewChartSchema = z.object({})
+
+export const handler = postHandler(
+  ReviewChartSchema,
+  (ctx: OpenEncounterContext) =>
+    redirect(`${ctx.state.open_encounter_pathname}/review_chart`),
+)
+
+export default HealthWorkerHomePage(
+  'Patient Chart',
+  async function ReviewChartPage(ctx: OpenEncounterContext) {
+    const {
+      trx,
+      health_worker,
+      encounter,
+      organization_id,
+      patient_encounter_id,
+    } = ctx.state
+
+    const referral = first(
+      await referrals.findAll(trx, {
+        patient_encounter_id,
+        originator_or_notified_health_worker_id: health_worker.id,
+      }),
+    )
+    assertOr403(referral, 'You are not authorized to review this chart')
+
+    const { findings, this_visit_diagnoses } = await promiseProps({
+      findings: this_visit_findings.get(trx, {
+        health_worker_id: health_worker.id,
+        encounter,
+        current_workflow_state: null,
+      }),
+      this_visit_diagnoses: diagnoses.get(trx, {
+        encounter,
+        health_worker_id: health_worker.id,
+      }),
+    })
+
+    const { patient, priority, notes } = encounter
+
+    return (
+      <div className='py-6 max-w-4xl mx-auto flex flex-col gap-6'>
+        <div className='flex items-start justify-between gap-4'>
+          <p className='text-sm text-gray-600 max-w-2xl'>
+            Review this patient's current encounter before responding to the
+            referral.
+          </p>
+          <Button
+            href='/app/notifications'
+            variant='secondary'
+            size='sm'
+            className='shrink-0'
+          >
+            Back
+          </Button>
+        </div>
+
+        <div className='bg-white shadow rounded-lg p-6'>
+          <div className='flex items-start justify-between gap-4'>
+            <div className='min-w-0 flex-1'>
+              <h2 className='text-xl font-semibold text-gray-900'>
+                {patient.name || '[Unnamed Patient]'}
+              </h2>
+              {patient.description && (
+                <p className='mt-1 text-sm text-gray-500'>
+                  {patient.description}
+                </p>
+              )}
+            </div>
+            <div id='patient-drawer-priority' className='shrink-0'>
+              <PriorityBadge priority={priority?.name ?? null} />
+            </div>
+          </div>
+        </div>
+
+        <div className='bg-white shadow rounded-lg p-6'>
+          <DrawerThisVisit
+            id='review-chart-this-visit'
+            organization_id={organization_id}
+            this_visit_findings={findings}
+            this_visit_diagnoses={this_visit_diagnoses}
+          />
+        </div>
+
+        {notes && (
+          <div className='bg-white shadow rounded-lg p-6 flex flex-col gap-2'>
+            <SectionHeader>Notes</SectionHeader>
+            <p className='text-sm text-gray-700'>{notes}</p>
+          </div>
+        )}
+      </div>
+    )
+  },
+)

--- a/routes/app/organizations/[organization_id]/patients/[patient_id]/open_encounter/triage/route_patient.tsx
+++ b/routes/app/organizations/[organization_id]/patients/[patient_id]/open_encounter/triage/route_patient.tsx
@@ -6,7 +6,13 @@ import { assert } from 'std/assert/assert.ts'
 import { patient_presence } from '../../../../../../../../db/models/patient_presence.ts'
 import redirect from '../../../../../../../../util/redirect.ts'
 import { completedPersonal } from '../../../../../../../../shared/patient_registration.ts'
-import { OpenEncounterWorkflowContext, TaskGroup, UpdateShape } from '../../../../../../../../types.ts'
+import {
+  OpenEncounterWorkflowContext,
+  RenderedFindingRelativeToHealthWorker,
+  RenderedSidebarWorkflow,
+  TaskGroup,
+  UpdateShape,
+} from '../../../../../../../../types.ts'
 import { DB } from '../../../../../../../../db.d.ts'
 import { success } from '../../../../../../../../util/alerts.ts'
 import { completeLastStep, OpenEncounterWorkflowPage } from '../_middleware.tsx'
@@ -22,6 +28,35 @@ import { referrals } from '../../../../../../../../db/models/referrals.ts'
 import { positiveRecordsFromEncounter } from '../../../../../../../../shared/recommended_dose_calculator/patient_case_from_encounter.ts'
 import { PatientCaseSchema } from '../../../../../../../../shared/recommended_doses.ts'
 import { recommended_dose_calculator } from '../../../../../../../../db/models/recommended_dose_calculator.ts'
+import { caseReferralNotificationDescription } from '../../../../../../../../shared/notifications/case_referral_notification.ts'
+import { employeeDisplay } from '../../../../../../../../util/healthWorkerDisplay.ts'
+import { priorityOrder } from '../../../../../../../../shared/sats.ts'
+import sortBy from '../../../../../../../../util/sortBy.ts'
+import first from '../../../../../../../../util/first.ts'
+
+function presentingIssueFromTriageFindings(
+  this_visit_findings: RenderedSidebarWorkflow[],
+): string | null {
+  const positive_findings: RenderedFindingRelativeToHealthWorker[] = this_visit_findings.flatMap(
+    (workflow) =>
+      workflow.steps
+        .filter((step) =>
+          step.workflow_step === 'warning_signs' ||
+          step.workflow_step === 'additional_tasks_and_investigations'
+        )
+        .flatMap((step) =>
+          step.records.flatMap((record) =>
+            record.type === 'finding' &&
+              record.existence === 'Yes' &&
+              record.value?.type !== 'measurement'
+              ? [record]
+              : []
+          )
+        ),
+  )
+
+  return first(sortBy(positive_findings, priorityOrder))?.displays.finding ?? null
+}
 
 export const TriageRoutePatientSchema = z.object({
   next_step: z.enum(TRIAGE_ROUTE_PATIENT_NEXT_STEPS),
@@ -32,7 +67,17 @@ export const TriageRoutePatientSchema = z.object({
 export const handler = postHandler(
   TriageRoutePatientSchema,
   async (ctx: OpenEncounterWorkflowContext, { next_step, health_worker_ids_to_be_notified }) => {
-    const { trx, patient, patient_encounter_id, organization, organization_employment, health_worker_id } = ctx.state
+    const {
+      trx,
+      patient,
+      patient_encounter_id,
+      organization,
+      organization_employment,
+      health_worker_id,
+      employee,
+      encounter,
+      this_visit_findings,
+    } = ctx.state
 
     assert(completedPersonal(patient))
     const completing_last_step = completeLastStep(ctx)
@@ -70,6 +115,7 @@ export const handler = postHandler(
       }
 
       case 'check_with_colleague': {
+        assert(encounter.priority)
         const { redirect_to } = await promiseProps({
           completing_last_step,
           redirect_to: startWorkflow(
@@ -88,6 +134,11 @@ export const handler = postHandler(
             originator_health_worker_id: health_worker_id,
             originator_avatar_url: ctx.state.health_worker.avatar_url!,
             health_worker_ids_to_be_notified,
+            notification_description: caseReferralNotificationDescription({
+              originator_display_name: employeeDisplay(employee).display_name,
+              priority_name: encounter.priority.name,
+              presenting_issue: presentingIssueFromTriageFindings(this_visit_findings),
+            }),
           }),
         })
         return redirect(redirect_to)

--- a/shared/notifications/case_referral_notification.ts
+++ b/shared/notifications/case_referral_notification.ts
@@ -1,0 +1,13 @@
+export function caseReferralNotificationDescription({
+  originator_display_name,
+  priority_name,
+  presenting_issue,
+}: {
+  originator_display_name: string
+  priority_name: string
+  presenting_issue?: string | null
+}): string {
+  const issue = presenting_issue?.trim()
+  const suffix = issue ? `: ${issue.toLowerCase()}` : ''
+  return `${originator_display_name} referred a ${priority_name} priority case to you${suffix}`
+}

--- a/test/shared/notifications/case_referral_notification.test.ts
+++ b/test/shared/notifications/case_referral_notification.test.ts
@@ -1,0 +1,55 @@
+import { describe, it } from 'std/testing/bdd.ts'
+import { assertEquals } from 'std/assert/assert_equals.ts'
+import { caseReferralNotificationDescription } from '../../../shared/notifications/case_referral_notification.ts'
+
+describe('shared/notifications/case_referral_notification.ts', () => {
+  describe('caseReferralNotificationDescription', () => {
+    it('includes the presenting issue when provided', () => {
+      assertEquals(
+        caseReferralNotificationDescription({
+          originator_display_name: 'Dr. Ada',
+          priority_name: 'urgent',
+          presenting_issue: 'Chest Pain',
+        }),
+        'Dr. Ada referred a urgent priority case to you: chest pain',
+      )
+    })
+
+    it('trims whitespace from the presenting issue', () => {
+      assertEquals(
+        caseReferralNotificationDescription({
+          originator_display_name: 'Dr. Ada',
+          priority_name: 'urgent',
+          presenting_issue: '  Chest Pain  ',
+        }),
+        'Dr. Ada referred a urgent priority case to you: chest pain',
+      )
+    })
+
+    it('omits the suffix when the presenting issue is missing', () => {
+      assertEquals(
+        caseReferralNotificationDescription({
+          originator_display_name: 'Dr. Ada',
+          priority_name: 'urgent',
+        }),
+        'Dr. Ada referred a urgent priority case to you',
+      )
+      assertEquals(
+        caseReferralNotificationDescription({
+          originator_display_name: 'Dr. Ada',
+          priority_name: 'urgent',
+          presenting_issue: null,
+        }),
+        'Dr. Ada referred a urgent priority case to you',
+      )
+      assertEquals(
+        caseReferralNotificationDescription({
+          originator_display_name: 'Dr. Ada',
+          priority_name: 'urgent',
+          presenting_issue: '   ',
+        }),
+        'Dr. Ada referred a urgent priority case to you',
+      )
+    })
+  })
+})

--- a/test/web/patients/open_encounter/triage/route_patient.test.ts
+++ b/test/web/patients/open_encounter/triage/route_patient.test.ts
@@ -30,7 +30,7 @@ describeParallel('triage/additional_tasks_and_investigations', () => {
     'routes to the referral placed page after referring an anaphylaxis case, creating a notification for another health worker',
     async () => {
       const insect_bite_s_expr = '(clinical_finding (snomed_concept "Itching" "finding"))'
-      const { $: $additional_tasks, patient_encounter_id, shcp, postStep, getStep } = await setupTriageNewPatient({
+      const { $: $additional_tasks, patient_encounter_id, nurse, shcp, postStep, getStep } = await setupTriageNewPatient({
         patient_demographics: randomDemographics('ZA', 'female', 'adult'),
         warning_signs: asWarningSignsAdult([], { pregnant: false }, insect_bite_s_expr),
         brief_history: {
@@ -129,6 +129,26 @@ describeParallel('triage/additional_tasks_and_investigations', () => {
         health_worker_id: shcp.id,
       })
       assertLength(notifications_of_shcp_post, 1)
+      const referral_notification = first(notifications_of_shcp_post)
+      assert(referral_notification)
+      assertEquals(referral_notification.notification_type, 'case_referral')
+      assertEquals(referral_notification.title, 'Chart review')
+      assert(
+        referral_notification.description.includes(nurse.health_worker.name),
+        `expected referrer name in description: ${referral_notification.description}`,
+      )
+      assert(
+        referral_notification.description.includes('Urgent'),
+        `expected priority in description: ${referral_notification.description}`,
+      )
+      assert(
+        referral_notification.description.includes('itching'),
+        `expected presenting issue in description: ${referral_notification.description}`,
+      )
+      assert(
+        referral_notification.description !== 'A case was referred to you to review',
+        `expected enriched description, got generic copy: ${referral_notification.description}`,
+      )
     },
   )
 

--- a/test/web/patients/open_encounter/triage/route_patient.test.ts
+++ b/test/web/patients/open_encounter/triage/route_patient.test.ts
@@ -30,7 +30,16 @@ describeParallel('triage/additional_tasks_and_investigations', () => {
     'routes to the referral placed page after referring an anaphylaxis case, creating a notification for another health worker',
     async () => {
       const insect_bite_s_expr = '(clinical_finding (snomed_concept "Itching" "finding"))'
-      const { $: $additional_tasks, patient_encounter_id, nurse, shcp, postStep, getStep } = await setupTriageNewPatient({
+      const {
+        $: $additional_tasks,
+        patient_encounter_id,
+        nurse,
+        shcp,
+        postStep,
+        getStep,
+        openEncounterRoute,
+        encounter,
+      } = await setupTriageNewPatient({
         patient_demographics: randomDemographics('ZA', 'female', 'adult'),
         warning_signs: asWarningSignsAdult([], { pregnant: false }, insect_bite_s_expr),
         brief_history: {
@@ -148,6 +157,60 @@ describeParallel('triage/additional_tasks_and_investigations', () => {
       assert(
         referral_notification.description !== 'A case was referred to you to review',
         `expected enriched description, got generic copy: ${referral_notification.description}`,
+      )
+      assertEquals(referral_notification.action.title, 'Review Chart')
+      assert(
+        referral_notification.action.href.endsWith('/open_encounter/review_chart'),
+        `expected review_chart action href, got ${referral_notification.action.href}`,
+      )
+      assert(
+        !referral_notification.action.href.includes('/start-workflow/chart_review'),
+        `notification action should not start chart_review workflow: ${referral_notification.action.href}`,
+      )
+      assertEquals(
+        referral_notification.action.href,
+        openEncounterRoute('review_chart'),
+      )
+
+      const shcp_with_session = await addSessionForEmployee(db, shcp)
+      const $review_chart = await shcp_with_session.fetchCheerio(
+        referral_notification.action.href,
+        { method: 'POST' },
+      )
+      assert(
+        $review_chart.url.endsWith('/open_encounter/review_chart'),
+        `expected review_chart page, got ${$review_chart.url}`,
+      )
+      assert($review_chart.text().includes('Patient Chart'))
+      assert($review_chart.text().includes('Back'))
+      assert(encounter.patient.name)
+      assert($review_chart.text().includes(encounter.patient.name))
+      assertEquals($review_chart('#patient-drawer-priority').text().trim(), 'Urgent')
+      assert(
+        $review_chart.text().toLowerCase().includes('itching'),
+        `expected itching finding on review_chart page: ${$review_chart('#review-chart-this-visit').text()}`,
+      )
+
+      const encounter_after_review = await patient_encounters.getById(db, patient_encounter_id)
+      assertEquals(
+        encounter_after_review.workflows.chart_review?.status,
+        'not started',
+        'notification Review Chart must not start chart_review',
+      )
+
+      const $review_chart_again = await shcp_with_session.fetchCheerio(
+        referral_notification.action.href,
+        { method: 'POST' },
+      )
+      assert(
+        $review_chart_again.url.endsWith('/open_encounter/review_chart'),
+        `expected review_chart to remain accessible, got ${$review_chart_again.url}`,
+      )
+      assert($review_chart_again.text().includes('Patient Chart'))
+      assertEquals(
+        (await patient_encounters.getById(db, patient_encounter_id)).workflows
+          .chart_review?.status,
+        'not started',
       )
     },
   )


### PR DESCRIPTION
## Summary

Improves the referral notification flow so the recipient gets useful context upfront and can review the patient chart directly from the notification.

Changes include:
- richer case referral notification copy with referrer name, encounter priority, and presenting issue
- a reusable read-only `Patient Chart` page for referral review
- `Review Chart` now opens the patient chart instead of starting the one-time `chart_review` workflow
- notification action styling now looks more like a button
- live updates on `/app/notifications` page 1 when new notifications arrive

Example notification:

`Chart review — Dr. Jane Smith referred a Urgent priority case to you: itching`

## Notes

The existing notification delivery pipeline stays the same. The richer copy is written to the existing notification `description`, so toast, in-app notifications, browser notifications, and web push all pick it up automatically.

The `Review Chart` action no longer starts or completes workflow state. It opens a read-only chart page that can be accessed repeatedly while the encounter is open.

The notifications page now reuses the existing WebSocket `notification` event to prepend new notifications on page 1 without refresh. Pagination, toast behavior, WebSocket protocol, and notification action behavior are unchanged.

No schema changes.

## Testing

- Added formatter coverage
- Updated triage referral tests for enriched notification copy
- Added coverage that referral `Review Chart` opens the patient chart and does not start `chart_review`
- Manually verified that notifications page 1 updates live when a new notification arrives
- Ran `deno task test test/shared/notifications/case_referral_notification.test.ts`
- Ran `deno task test test/web/patients/open_encounter/triage/route_patient.test.ts`
- Ran `deno task test test/web/notifications/seen.test.ts`

<img width="896" height="202" alt="image" src="https://github.com/user-attachments/assets/9f9d7551-b4ba-4014-b80e-250305139768" />

<img width="1510" height="855" alt="image" src="https://github.com/user-attachments/assets/ae94b97f-87f2-4064-b6e2-f35796a62e45" />

