### PR TITLE
Hardcode IFA map rules for SNOMED→ICD-10, including age-at-onset AND case

### DIFF
--- a/components/library/MedicineCard.tsx
+++ b/components/library/MedicineCard.tsx
@@ -77,7 +77,7 @@ function PrescriberInfo(
   const Icon = ROLE_ICONS[permitted] ?? UserIcon
 
   return (
-    <div class='flex items-center gap-2 text-xs text-gray-500'>
+    <div class='flex items-center gap-2 text-xs text-gray-500' data-permitted={permitted}>
       <Icon className='w-4 h-4 flex-none' />
       <span>Prescribable by {permitted}</span>
       {employees.length > 0 && (

--- a/db/models/snomed_to_icd10.ts
+++ b/db/models/snomed_to_icd10.ts
@@ -1,3 +1,4 @@
+import { assert } from 'std/assert/assert.ts'
 import {
   primaryIcd10CodesFromSnomedMappings,
   SNOMED_ICD10_COMPLEX_MAP_REFSET_ID,
@@ -26,19 +27,92 @@ type ExtendedMapRow = {
   correlation_id: string | bigint
 }
 
-function ifaContextConceptId(map_rule: string): string | null {
-  const match = map_rule.match(/^IFA (\d+)/)
-  return match?.[1] ?? null
+// The International Extended Map (release 2025-12-01) contains exactly 9
+// non-TRUE/OTHERWISE map_rule rows, 8 distinct clauses (one row is a compound
+// AND of two age-at-onset clauses). Hardcoded per mentor guidance rather than
+// generically parsed, since the set is small and stable. If a future SNOMED
+// release introduces a rule outside this set, evaluateIFAClause asserts below
+// so we notice and add explicit handling instead of silently mismapping.
+const SEX_IFA_RULES: Record<string, 'female' | 'male'> = {
+  [`IFA ${SNOMED_IFA_FEMALE_CONCEPT_ID} | Female (finding) |`]: 'female',
+  [`IFA ${SNOMED_IFA_MALE_CONCEPT_ID} | Male (finding) |`]: 'male',
 }
 
-function ifaRuleMatches(map_rule: string, context: SnomedIcd10PatientContext): boolean {
-  const concept_id = ifaContextConceptId(map_rule)
-  if (!concept_id) return false
-  if (concept_id === SNOMED_IFA_FEMALE_CONCEPT_ID) return context.sex === 'female'
-  if (concept_id === SNOMED_IFA_MALE_CONCEPT_ID) return context.sex === 'male'
-  // Age-at-onset IFA rules need the age when the finding began, not current age from DOB.
-  if (concept_id === SNOMED_IFA_AGE_AT_ONSET_CONCEPT_ID) return false
-  return false
+type AgeAtOnsetClause = {
+  comparator: '<' | '<=' | '>='
+  value: number
+  unit: 'years' | 'days'
+}
+
+const AGE_AT_ONSET_IFA_PREFIX = `IFA ${SNOMED_IFA_AGE_AT_ONSET_CONCEPT_ID} | Age at onset of clinical finding (observable entity) | `
+
+// Includes '>= 12.0 years', which never appears as its own row — only as the
+// first clause of the single AND row.
+const AGE_AT_ONSET_IFA_CLAUSES: Record<string, AgeAtOnsetClause> = {
+  [`${AGE_AT_ONSET_IFA_PREFIX}< 15.0 years`]: { comparator: '<', value: 15, unit: 'years' },
+  [`${AGE_AT_ONSET_IFA_PREFIX}<= 15.0 years`]: { comparator: '<=', value: 15, unit: 'years' },
+  [`${AGE_AT_ONSET_IFA_PREFIX}< 19.0 years`]: { comparator: '<', value: 19, unit: 'years' },
+  [`${AGE_AT_ONSET_IFA_PREFIX}< 28.0 days`]: { comparator: '<', value: 28, unit: 'days' },
+  [`${AGE_AT_ONSET_IFA_PREFIX}<= 18.0 years`]: { comparator: '<=', value: 18, unit: 'years' },
+  [`${AGE_AT_ONSET_IFA_PREFIX}>= 65.0 years`]: { comparator: '>=', value: 65, unit: 'years' },
+  [`${AGE_AT_ONSET_IFA_PREFIX}>= 12.0 years`]: { comparator: '>=', value: 12, unit: 'years' },
+}
+
+// Age in days between the patient's DOB and when the finding/diagnosis was
+// recorded — this is what the age-at-onset IFA rules actually need, not the
+// patient's current age. Returns null if either date is missing/invalid so
+// callers can fall through to TRUE/OTHERWISE rather than mismatching on NaN.
+function ageAtOnsetInDays(dob: string, onset_date: Date | string): number | null {
+  const birth_date = new Date(dob)
+  const onset = new Date(onset_date)
+  if (Number.isNaN(birth_date.getTime()) || Number.isNaN(onset.getTime())) return null
+  return (onset.getTime() - birth_date.getTime()) / (1000 * 60 * 60 * 24)
+}
+
+function evaluateAgeAtOnsetClause(clause: AgeAtOnsetClause, onset_age_days: number): boolean {
+  const threshold_days = clause.unit === 'years' ? clause.value * 365.25 : clause.value
+  switch (clause.comparator) {
+    case '<':
+      return onset_age_days < threshold_days
+    case '<=':
+      return onset_age_days <= threshold_days
+    case '>=':
+      return onset_age_days >= threshold_days
+  }
+}
+
+// Evaluates a single (non-AND) clause.
+// Returns true/false when it can be resolved with available context.
+// Returns null when the clause is an age-at-onset check but we don't have an
+// onset date for this finding (caller should fall through to TRUE/OTHERWISE).
+function evaluateIFAClause(
+  clause: string,
+  context: SnomedIcd10PatientContext,
+  onset_age_days: number | null,
+): boolean | null {
+  const sex = SEX_IFA_RULES[clause]
+  if (sex) return context.sex === sex
+
+  const age_clause = AGE_AT_ONSET_IFA_CLAUSES[clause]
+  if (age_clause) {
+    if (onset_age_days === null) return null
+    return evaluateAgeAtOnsetClause(age_clause, onset_age_days)
+  }
+
+  assert(false, `Unexpected IFA map_rule clause: ${clause}`)
+}
+
+// Handles the single known AND rule generically by splitting on ' AND ' and
+// requiring every clause to resolve to true. Any clause that can't be
+// resolved (missing onset date) makes the whole rule unresolved.
+function evaluateIFARule(
+  map_rule: string,
+  context: SnomedIcd10PatientContext,
+  onset_age_days: number | null,
+): boolean | null {
+  const results = map_rule.split(' AND ').map((clause) => evaluateIFAClause(clause.trim(), context, onset_age_days))
+  if (results.some((result) => result === null)) return null
+  return results.every((result) => result === true)
 }
 
 function isOtherwiseRule(map_rule: string | null): boolean {
@@ -55,6 +129,7 @@ function comparePriority(
 function resolveMapGroup(
   rows: ExtendedMapRow[],
   context: SnomedIcd10PatientContext,
+  onset_age_days: number | null,
 ): { code: SnomedIcd10CodeMapping | null; status: SnomedIcd10MapStatus | null } {
   const ifa_rows = rows
     .filter((row) => row.map_rule?.startsWith('IFA '))
@@ -63,7 +138,7 @@ function resolveMapGroup(
   const otherwise_row = rows.find((row) => isOtherwiseRule(row.map_rule))
 
   for (const row of ifa_rows) {
-    if (ifaRuleMatches(row.map_rule!, context) && row.map_target) {
+    if (evaluateIFARule(row.map_rule!, context, onset_age_days) === true && row.map_target) {
       return {
         code: rowToCodeMapping(row, 'context'),
         status: 'mapped',
@@ -126,6 +201,7 @@ function buildConceptMapping(
   snomed_concept_id: string,
   rows: ExtendedMapRow[],
   context: SnomedIcd10PatientContext,
+  onset_age_days: number | null,
 ): SnomedIcd10ConceptMapping {
   if (!rows.length) {
     return {
@@ -149,7 +225,7 @@ function buildConceptMapping(
   for (const map_group of [...rows_by_group.keys()].sort((left, right) => left - right)) {
     const group_rows = rows_by_group.get(map_group)
     if (!group_rows) continue
-    const resolved = resolveMapGroup(group_rows, context)
+    const resolved = resolveMapGroup(group_rows, context, onset_age_days)
     if (resolved.code) {
       codes.push(resolved.code)
     } else if (resolved.status === 'unresolved_context' || resolved.status === 'not_classifiable') {
@@ -207,12 +283,14 @@ export const snomed_to_icd10 = {
 
     const by_concept = new Map()
     for (const positive_record of positive_records) {
+      const onset_age_days = ageAtOnsetInDays(context.dob, positive_record.created_at)
       by_concept.set(
         positive_record,
         buildConceptMapping(
           positive_record.specific_snomed_concept_id,
           rows_by_concept.get(positive_record.specific_snomed_concept_id) ?? [],
           context,
+          onset_age_days,
         ),
       )
     }

--- a/test/models/snomed_to_icd10.test.ts
+++ b/test/models/snomed_to_icd10.test.ts
@@ -8,10 +8,23 @@ import { PEPTIC_ULCER } from '../../shared/snomed_concepts.ts'
 
 const adult_context = { sex: 'female' as const, dob: '1988-01-01' }
 
-// mapConcepts only reads the record's SNOMED concept id; the result map is
-// keyed by the record itself
-function asPositiveRecord(specific_snomed_concept_id: string): RenderedPositiveRecordRelativeToHealthWorker {
-  return { specific_snomed_concept_id } as RenderedPositiveRecordRelativeToHealthWorker
+// mapConcepts reads the record's SNOMED concept id and created_at (onset date for
+// age-at-onset IFA rules). The result map is keyed by the record itself.
+function asPositiveRecord(
+  specific_snomed_concept_id: string,
+  created_at?: Date | string,
+): RenderedPositiveRecordRelativeToHealthWorker {
+  return {
+    specific_snomed_concept_id,
+    ...(created_at !== undefined ? { created_at } : {}),
+  } as RenderedPositiveRecordRelativeToHealthWorker
+}
+
+function mappedCodes(
+  result: Awaited<ReturnType<typeof snomed_to_icd10.mapConcepts>>,
+  record: RenderedPositiveRecordRelativeToHealthWorker,
+) {
+  return result.by_concept.get(record)?.codes.map((code) => code.icd10_code)
 }
 
 describeParallel('db/models/snomed_to_icd10.ts', () => {
@@ -88,5 +101,128 @@ describeParallel('db/models/snomed_to_icd10.ts', () => {
   itParallel('returns an empty map when given no concepts', async () => {
     const result = await snomed_to_icd10.mapConcepts(db, adult_context, [])
     assertEquals(result.by_concept.size, 0)
+  })
+
+  // --- Hardcoded IFA rules (sex + age-at-onset, including AND) ---
+
+  itParallel('resolves sex IFA rules for infertility (8619003): female→N97.9, male→N46', async () => {
+    const record = asPositiveRecord('8619003')
+    const female_result = await snomed_to_icd10.mapConcepts(db, { sex: 'female', dob: '1988-01-01' }, [record])
+    assertEquals(mappedCodes(female_result, record), ['N97.9'])
+    assertEquals(female_result.by_concept.get(record)?.codes.find((c) => c.icd10_code === 'N97.9')?.resolved_via, 'context')
+
+    const male_result = await snomed_to_icd10.mapConcepts(db, { sex: 'male', dob: '1988-01-01' }, [record])
+    assertEquals(mappedCodes(male_result, record), ['N46'])
+  })
+
+  itParallel('resolves age-at-onset < 28 days (95350002): newborn→P83.0, older→M34.8', async () => {
+    const dob = '2024-01-01'
+    const context = { sex: 'female' as const, dob }
+
+    const newborn = asPositiveRecord('95350002', '2024-01-10') // 9 days old
+    const newborn_result = await snomed_to_icd10.mapConcepts(db, context, [newborn])
+    assertEquals(mappedCodes(newborn_result, newborn), ['P83.0'])
+    assertEquals(newborn_result.by_concept.get(newborn)?.codes.find((c) => c.icd10_code === 'P83.0')?.resolved_via, 'context')
+
+    const older = asPositiveRecord('95350002', '2024-03-01') // ~2 months
+    const older_result = await snomed_to_icd10.mapConcepts(db, context, [older])
+    assertEquals(mappedCodes(older_result, older), ['M34.8'])
+    assertEquals(older_result.by_concept.get(older)?.codes.find((c) => c.icd10_code === 'M34.8')?.resolved_via, 'fallback')
+  })
+
+  itParallel('resolves age-at-onset <= 15 years (13617004): child→J20.9, adult→J40', async () => {
+    const child = asPositiveRecord('13617004', '2024-01-01') // onset at ~14y with dob 2010
+    const child_result = await snomed_to_icd10.mapConcepts(
+      db,
+      { sex: 'female', dob: '2010-01-01' },
+      [child],
+    )
+    assertEquals(mappedCodes(child_result, child), ['J20.9'])
+
+    const adult = asPositiveRecord('13617004', '2024-01-01') // onset at ~24y
+    const adult_result = await snomed_to_icd10.mapConcepts(
+      db,
+      { sex: 'female', dob: '2000-01-01' },
+      [adult],
+    )
+    assertEquals(mappedCodes(adult_result, adult), ['J40'])
+  })
+
+  itParallel('resolves age-at-onset < 15 years (785728005): under-15→J20.9, older→J40', async () => {
+    const under_15 = asPositiveRecord('785728005', '2024-01-01')
+    const under_15_result = await snomed_to_icd10.mapConcepts(
+      db,
+      { sex: 'female', dob: '2010-06-01' }, // ~13.5y
+      [under_15],
+    )
+    assertEquals(mappedCodes(under_15_result, under_15), ['J20.9'])
+
+    const over_15 = asPositiveRecord('785728005', '2024-01-01')
+    const over_15_result = await snomed_to_icd10.mapConcepts(
+      db,
+      { sex: 'female', dob: '2005-01-01' }, // ~19y
+      [over_15],
+    )
+    assertEquals(mappedCodes(over_15_result, over_15), ['J40'])
+  })
+
+  itParallel('resolves age-at-onset <=18 / >=65 on same concept (717934004)', async () => {
+    // priority 1: <= 18y → E55.0
+    const adolescent = asPositiveRecord('717934004', '2024-01-01')
+    const adolescent_result = await snomed_to_icd10.mapConcepts(
+      db,
+      { sex: 'female', dob: '2010-01-01' }, // ~14y
+      [adolescent],
+    )
+    assertEquals(mappedCodes(adolescent_result, adolescent), ['E55.0'])
+
+    // priority 2: >= 65y → M83.19
+    const elderly = asPositiveRecord('717934004', '2024-01-01')
+    const elderly_result = await snomed_to_icd10.mapConcepts(
+      db,
+      { sex: 'female', dob: '1950-01-01' }, // ~74y
+      [elderly],
+    )
+    assertEquals(mappedCodes(elderly_result, elderly), ['M83.19'])
+
+    // OTHERWISE → M83.89
+    const middle_age = asPositiveRecord('717934004', '2024-01-01')
+    const middle_age_result = await snomed_to_icd10.mapConcepts(
+      db,
+      { sex: 'female', dob: '1980-01-01' }, // ~44y
+      [middle_age],
+    )
+    assertEquals(mappedCodes(middle_age_result, middle_age), ['M83.89'])
+  })
+
+  itParallel('resolves the AND age-at-onset rule (440311000124109): [12,19)→Z00.3, <19→Z00.2', async () => {
+    // priority 1: >= 12 AND < 19 → Z00.3
+    const teen = asPositiveRecord('440311000124109', '2024-01-01')
+    const teen_result = await snomed_to_icd10.mapConcepts(
+      db,
+      { sex: 'female', dob: '2009-01-01' }, // ~15y
+      [teen],
+    )
+    assertEquals(mappedCodes(teen_result, teen), ['Z00.3'])
+    assertEquals(teen_result.by_concept.get(teen)?.codes.find((c) => c.icd10_code === 'Z00.3')?.resolved_via, 'context')
+
+    // priority 2: < 19 (AND fails because age < 12) → Z00.2
+    const young_child = asPositiveRecord('440311000124109', '2024-01-01')
+    const young_child_result = await snomed_to_icd10.mapConcepts(
+      db,
+      { sex: 'female', dob: '2019-01-01' }, // ~5y
+      [young_child],
+    )
+    assertEquals(mappedCodes(young_child_result, young_child), ['Z00.2'])
+
+    // both IFA rules fail; OTHERWISE TRUE has null target → unresolved_context
+    const adult = asPositiveRecord('440311000124109', '2024-01-01')
+    const adult_result = await snomed_to_icd10.mapConcepts(
+      db,
+      { sex: 'female', dob: '1990-01-01' }, // ~34y
+      [adult],
+    )
+    assertEquals(adult_result.by_concept.get(adult)?.status, 'unresolved_context')
+    assertEquals(mappedCodes(adult_result, adult), [])
   })
 })

--- a/test/web/patients/open_encounter/triage/recommended_doses.test.ts
+++ b/test/web/patients/open_encounter/triage/recommended_doses.test.ts
@@ -58,7 +58,7 @@ describeParallel('triage/route_patient recommended medicines', () => {
 
     // Doctor-only options can't be prescribed by the triage nurse, and this
     // clinic staffs no doctor, so a doctor role icon is shown
-    assert($.html().includes('can be prescribed by'))
+    assert($.html().includes('Prescribable by'))
     assert($('[data-permitted="doctor"]').length, 'expected a doctor role icon for doctor-only prescriptions')
   })
 })


### PR DESCRIPTION
- Hardcode the 9 known IFA (If Applicable) map_rule clauses from the International Extended Map (2025-12-01 release): 2 sex-based rules and 7 age-at-onset rules (including the single compound AND rule for the 12–19 year adolescent range).
- Age-at-onset rules are evaluated using the *onset* age (derived from the positive record's `created_at` and the patient's `dob`), not the patient's current age — previously always fell through to the unconditional/fallback code.
- The AND rule is handled generically by splitting on `' AND '` and requiring every clause to resolve `true`; if any clause can't be resolved (e.g. missing onset date), the whole rule returns `null` and falls through to `TRUE`/`OTHERWISE`.
- Added an assertion for any IFA clause outside the known set, so a future SNOMED release fails loudly instead of silently mismapping.
- Added model test cases covering sex-based resolution, age thresholds, and the AND rule (teen match, younger-child fallback, adult unresolved_context).